### PR TITLE
feat: apply reviewed maintenance updates

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -16,6 +16,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Labeler
-        uses: actions/labeler@v6
+        uses: actions/labeler@v7
         with:
           configuration-path: .github/labeler.yaml

--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: 2.20.15
+              tag: 3.0.4
             env:
               # Application
               PAPERLESS_URL: https://paperless.davidhome.ro
@@ -54,13 +54,13 @@ spec:
               PAPERLESS_EXPORT_DIR: /data/nas/export
               PAPERLESS_MEDIA_ROOT: /data/local/media
               # Consumer Settings
-              PAPERLESS_CONSUMER_POLLING: "60"
+              PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"
               PAPERLESS_CONSUMER_RECURSIVE: "true"
               PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: "true"
               # OCR
               PAPERLESS_OCR_LANGUAGE: eng
               PAPERLESS_OCR_LANGUAGES: eng
-              PAPERLESS_OCR_SKIP_ARCHIVE_FILE: with_text
+              PAPERLESS_ARCHIVE_FILE_GENERATION: auto
               # Tika & Gotenberg (document conversion)
               PAPERLESS_TIKA_ENABLED: "true"
               PAPERLESS_TIKA_ENDPOINT: http://tika.default.svc.cluster.local:9998

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 82.18.0
+      version: 87.21.0
       sourceRef:
         kind: HelmRepository
         name: prometheus-community

--- a/kubernetes/apps/observability/kube-prometheus-stack/crds/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/crds/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prometheus-operator-crds
-      version: 29.0.0
+      version: 30.0.1
       sourceRef:
         kind: HelmRepository
         name: prometheus-community

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: prometheus-operator-crds
-      version: 29.0.0
+      version: 30.0.1
       sourceRef:
         kind: HelmRepository
         name: prometheus-community

--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
   - name: prometheus-operator-crds
     namespace: observability
     chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
-    version: 29.0.0
+    version: 30.0.1
 
   - name: cilium
     namespace: kube-system

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cloudflare==5.4.0
+cloudflare==5.6.0
 dnspython==2.8.0
 email-validator==2.3.0
 makejinja==2.8.2


### PR DESCRIPTION
## Summary

- update kube-prometheus-stack to 87.21.0
- keep Prometheus Operator CRDs aligned at 30.0.1 / operator 0.92.1 across Flux and bootstrap
- update Paperless-ngx to 3.0.4 with required v3 consumer and archive settings
- update actions/labeler to v7
- update cloudflare Python dependency to 5.6.0

## Safety checks

- Paperless is already on the required 2.20.15 upgrade prerequisite
- PAPERLESS_SECRET_KEY exists in the encrypted secret
- latest Paperless VolSync backup succeeded before this update
- targeted Kustomize builds and YAML parsing pass
- all unrelated Renovate updates are intentionally excluded

The local talosctl update was separately merged in #659.