### PR TITLE
Add Envoy Gateway test platform

### DIFF
--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/envoyproxy.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/envoyproxy.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: nextjs-shared-proxy
+spec:
+  mergeGateways: true
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        name: nextjs-envoy
+        replicas: 2
+        container:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+        pod:
+          labels:
+            nextjs.davidilie.dev/gateway: shared
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  nextjs.davidilie.dev/gateway: shared
+      envoyService:
+        name: nextjs-envoy
+        type: LoadBalancer
+        externalTrafficPolicy: Cluster
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: nextjs-adapter-test.davidhome.ro,nextjs-control.davidhome.ro
+          lbipam.cilium.io/ips: 192.168.100.90
+      envoyPDB:
+        name: nextjs-envoy
+        minAvailable: 1
+      envoyServiceAccount:
+        name: nextjs-envoy
+  telemetry:
+    metrics:
+      prometheus:
+        disable: false

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/gatewayclass.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/gatewayclass.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: nextjs-shared-proxy
+    namespace: envoy-gateway-system

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/kustomization.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gatewayclass.yaml
+  - ./envoyproxy.yaml
+  - ./metrics-service.yaml
+  - ./monitoring.yaml

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/metrics-service.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/metrics-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-envoy-metrics
+  labels:
+    nextjs.davidilie.dev/metrics: envoy
+spec:
+  selector:
+    nextjs.davidilie.dev/gateway: shared
+  ports:
+    - name: metrics
+      port: 19001
+      protocol: TCP
+      targetPort: 19001

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/monitoring.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/monitoring.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-gateway
+spec:
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextjs-envoy
+spec:
+  selector:
+    matchLabels:
+      nextjs.davidilie.dev/metrics: envoy
+  endpoints:
+    - port: metrics
+      path: /stats/prometheus
+      interval: 30s

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/ks.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app envoy-gateway-config
+  namespace: &namespace envoy-gateway-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  path: ./kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app/helmrelease.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: gateway-helm
+      version: v1.8.3
+      sourceRef:
+        kind: HelmRepository
+        name: envoy-gateway
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    crds:
+      enabled: true
+    deployment:
+      replicas: 2
+      envoyGateway:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+      pod:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                control-plane: envoy-gateway
+    podDisruptionBudget:
+      minAvailable: 1
+    service:
+      type: ClusterIP

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app/kustomization.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/ks.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app envoy-gateway
+  namespace: &namespace envoy-gateway-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cilium
+      namespace: kube-system
+  path: ./kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/envoy-gateway-system/kustomization.yaml
+++ b/kubernetes/apps/envoy-gateway-system/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: envoy-gateway-system
+resources:
+  - ./envoy-gateway/controller/ks.yaml
+  - ./envoy-gateway/config/ks.yaml
+components:
+  - ../../flux/components/namespace

--- a/kubernetes/flux/meta/repositories/oci/envoy-gateway.yaml
+++ b/kubernetes/flux/meta/repositories/oci/envoy-gateway.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: envoy-gateway
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 5m
+  url: oci://docker.io/envoyproxy

--- a/kubernetes/flux/meta/repositories/oci/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/oci/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./actions-runner-controller.yaml
   - ./fluent-bit.yaml
   - ./victoria-metrics.yaml
+  - ./envoy-gateway.yaml


### PR DESCRIPTION
## Summary

- install Envoy Gateway v1.8.3 with its Gateway API CRDs
- create a shared two-replica Envoy data plane at `192.168.100.90`
- add Gateway and Envoy metrics discovery

## Testing

- rendered the Helm chart with the configured values
- validated each changed Kustomize tree with kubeconform