### PR TITLE
Add Envoy Gateway SOPS key

### DIFF
--- a/kubernetes/apps/envoy-gateway-system/kustomization.yaml
+++ b/kubernetes/apps/envoy-gateway-system/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./envoy-gateway/config/ks.yaml
 components:
   - ../../flux/components/namespace
+  - ../../flux/components/sops


### PR DESCRIPTION
## Summary

- add the shared SOPS key to the Envoy Gateway namespace
- satisfy the root Flux decryption patch
- unblock the Envoy Gateway child Kustomizations

## Testing

- validated the Envoy Gateway Kustomize tree with kubeconform