### PR TITLE
Add Next.js adapter test platform

### DIFF
--- a/kubernetes/apps/nextjs-adapter-test/kustomization.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nextjs-adapter-test
+resources:
+  - ./platform/ks.yaml
+components:
+  - ../../flux/components/namespace
+  - ../../flux/components/regcred
+  - ../../flux/components/sops

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/certificate.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nextjs-test
+spec:
+  secretName: nextjs-test-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - nextjs-adapter-test.davidhome.ro
+    - nextjs-control.davidhome.ro

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/control-gateway.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/control-gateway.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nextjs-control
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: nextjs-control.davidhome.ro
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: nextjs-control.davidhome.ro
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: nextjs-test-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nextjs-control
+spec:
+  parentRefs:
+    - name: nextjs-control
+      sectionName: https
+  hostnames:
+    - nextjs-control.davidhome.ro
+  rules:
+    - backendRefs:
+        - name: nextjs-control
+          port: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nextjs-control-http-redirect
+spec:
+  parentRefs:
+    - name: nextjs-control
+      sectionName: http
+  hostnames:
+    - nextjs-control.davidhome.ro
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            port: 443
+            statusCode: 302

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/control.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/control.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nextjs-control
+  labels:
+    app.kubernetes.io/name: nextjs-control
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextjs-control
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nextjs-control
+        app.kubernetes.io/component: control
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: nextjs
+          image: ghcr.io/davidilie/nextjs-adapter-k8s-testbed/control@sha256:e1750f9f9f97a1d9bf91a327407a49f26c307c697252e76923f353a08afd4915
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: APP_VARIANT
+              value: control
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: nextjs-test-runtime
+                  key: DATABASE_URL
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: nextjs-test-runtime
+                  key: REDIS_URL
+            - name: WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nextjs-test-runtime
+                  key: WEBHOOK_SECRET
+            - name: LOAD_TEST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nextjs-test-runtime
+                  key: LOAD_TEST_TOKEN
+            - name: OTEL_SERVICE_NAME
+              value: nextjs-adapter-testbed-control
+            - name: HOSTNAME
+              value: 0.0.0.0
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PORT
+              value: "3000"
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/health?mode=readiness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/health?mode=liveness
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /api/health?mode=liveness
+              port: http
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: next-cache
+              mountPath: /app/.next/cache
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: next-cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+      terminationGracePeriodSeconds: 45
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: nextjs-control
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-control
+  labels:
+    app.kubernetes.io/name: nextjs-control
+spec:
+  selector:
+    app.kubernetes.io/name: nextjs-control
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nextjs-control
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextjs-control

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/dnsendpoint.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/dnsendpoint.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: nextjs-adapter-test
+spec:
+  endpoints:
+    - dnsName: nextjs-adapter-test.davidhome.ro
+      recordType: CNAME
+      targets:
+        - external.davidhome.ro
+    - dnsName: nextjs-control.davidhome.ro
+      recordType: CNAME
+      targets:
+        - external.davidhome.ro

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/kustomization.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./certificate.yaml
+  - ./serviceaccount.yaml
+  - ./control.yaml
+  - ./control-gateway.yaml
+  - ./dnsendpoint.yaml
+  - ./metrics-services.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/metrics-services.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/metrics-services.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-control-metrics
+  labels:
+    nextjs.davidilie.dev/metrics: "true"
+    nextjs.davidilie.dev/runtime: control
+spec:
+  selector:
+    app.kubernetes.io/name: nextjs-control
+  ports:
+    - name: metrics
+      port: 3000
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-web-metrics
+  labels:
+    nextjs.davidilie.dev/metrics: "true"
+    nextjs.davidilie.dev/runtime: web
+spec:
+  selector:
+    app.kubernetes.io/name: nextjs-adapter-test
+    app.kubernetes.io/component: web
+  ports:
+    - name: metrics
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-api-metrics
+  labels:
+    nextjs.davidilie.dev/metrics: "true"
+    nextjs.davidilie.dev/runtime: api
+spec:
+  selector:
+    app.kubernetes.io/name: nextjs-adapter-test
+    app.kubernetes.io/component: api
+  ports:
+    - name: metrics
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-legacy-metrics
+  labels:
+    nextjs.davidilie.dev/metrics: "true"
+    nextjs.davidilie.dev/runtime: legacy
+spec:
+  selector:
+    app.kubernetes.io/name: nextjs-adapter-test
+    app.kubernetes.io/component: legacy
+  ports:
+    - name: metrics
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-heavy-metrics
+  labels:
+    nextjs.davidilie.dev/metrics: "true"
+    nextjs.davidilie.dev/runtime: heavy
+spec:
+  selector:
+    app.kubernetes.io/name: nextjs-adapter-test
+    app.kubernetes.io/component: heavy
+  ports:
+    - name: metrics
+      port: 3000
+      targetPort: 3000

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/serviceaccount.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false
+imagePullSecrets:
+  - name: docker-regcred

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/servicemonitor.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/servicemonitor.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextjs-control
+spec:
+  selector:
+    matchLabels:
+      nextjs.davidilie.dev/metrics: "true"
+      nextjs.davidilie.dev/runtime: control
+  endpoints:
+    - port: metrics
+      path: /api/metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextjs-web
+spec:
+  selector:
+    matchLabels:
+      nextjs.davidilie.dev/metrics: "true"
+      nextjs.davidilie.dev/runtime: web
+  endpoints:
+    - port: metrics
+      path: /api/metrics/web
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextjs-api
+spec:
+  selector:
+    matchLabels:
+      nextjs.davidilie.dev/metrics: "true"
+      nextjs.davidilie.dev/runtime: api
+  endpoints:
+    - port: metrics
+      path: /api/metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextjs-legacy
+spec:
+  selector:
+    matchLabels:
+      nextjs.davidilie.dev/metrics: "true"
+      nextjs.davidilie.dev/runtime: legacy
+  endpoints:
+    - port: metrics
+      path: /api/metrics/legacy
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nextjs-heavy
+spec:
+  selector:
+    matchLabels:
+      nextjs.davidilie.dev/metrics: "true"
+      nextjs.davidilie.dev/runtime: heavy
+  endpoints:
+    - port: metrics
+      path: /api/metrics/heavy
+      interval: 30s
+      scrapeTimeout: 10s

--- a/kubernetes/apps/nextjs-adapter-test/platform/ks.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/ks.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nextjs-adapter-test
+  namespace: &namespace nextjs-adapter-test
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/part-of: *app
+  dependsOn:
+    - name: envoy-gateway-config
+      namespace: envoy-gateway-system
+    - name: cert-manager-issuers
+      namespace: cert-manager
+    - name: cloudnative-pg
+      namespace: databases
+    - name: dragonfly
+      namespace: databases
+  path: ./kubernetes/apps/nextjs-adapter-test/platform/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m


### PR DESCRIPTION
## Summary

- add the isolated Next.js adapter test namespace and runtime prerequisites
- deploy the three-replica standalone control behind Envoy Gateway
- add TLS, split-horizon DNS, and per-runtime metrics discovery

## Testing

- validated both Kustomize trees with kubeconform
- passed Kubernetes server-side dry-run for all platform resources
- verified the pinned image architecture and runtime Secret