### PR TITLE
Route Next.js tests through Envoy

### DIFF
--- a/kubernetes/apps/network/external/cloudflared/configs/config.yaml
+++ b/kubernetes/apps/network/external/cloudflared/configs/config.yaml
@@ -5,6 +5,14 @@ originRequest:
 ingress:
   - hostname: "davidhome.ro"
     service: https://external-ingress-nginx-controller.network.svc.cluster.local:443
+  - hostname: "nextjs-adapter-test.davidhome.ro"
+    service: https://nextjs-envoy.envoy-gateway-system.svc.cluster.local:443
+    originRequest:
+      originServerName: "nextjs-adapter-test.davidhome.ro"
+  - hostname: "nextjs-control.davidhome.ro"
+    service: https://nextjs-envoy.envoy-gateway-system.svc.cluster.local:443
+    originRequest:
+      originServerName: "nextjs-control.davidhome.ro"
   - hostname: "*.davidhome.ro"
     service: https://external-ingress-nginx-controller.network.svc.cluster.local:443
   - hostname: "dave.tips"


### PR DESCRIPTION
## Summary

- route the adapter and control hostnames directly from Cloudflared to the shared Envoy Gateway
- verify origin TLS with the hostname for each Gateway listener
- keep the existing `*.davidhome.ro` traffic on NGINX

## Testing

- `cloudflared tunnel --config kubernetes/apps/network/external/cloudflared/configs/config.yaml ingress validate`
- `kustomize build kubernetes/apps/network/external/cloudflared`