### PR TITLE
fix(cluster): audit wave 1 — memory hygiene, CNPG base backups, volsync UID fix, drain-safe PDBs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@
 
 This is a **production home Kubernetes cluster** running on **Talos Linux** with **Flux GitOps**. Every push to this repository automatically updates the live cluster - exercise caution with all changes.
 
-- **Repository:** https://github.com/DavidIlie/home-cluster
-- **Cluster OS:** Talos Linux v1.10.x
-- **Kubernetes Version:** v1.33.x
+- **Repository:** https://github.com/DavidIlie/home-cluster (**PUBLIC**)
+- **Cluster OS:** Talos Linux v1.12.x (live: v1.12.1)
+- **Kubernetes Version:** v1.35.x (live: v1.35.0)
 - **GitOps:** Flux v2 (operator + instance pattern)
 - **Secrets:** SOPS with Age encryption
 - **Updates:** Renovate bot
+- **Reference cluster:** https://github.com/onedr0p/home-ops - use it as the reference for patterns and conventions when planning or writing anything here
 
 ## Critical Rules
 
@@ -17,6 +18,11 @@ This is a **production home Kubernetes cluster** running on **Talos Linux** with
 - **Talos OS version** - Manual updates only
 - **Kubernetes version** - Manual updates only
 - If a package update requires a newer Kubernetes version, **do not proceed** - flag it for manual review
+
+### NEVER Commit Plaintext Credentials
+- **This repository is PUBLIC.** Anything committed unencrypted is world-readable forever.
+- Passwords, API keys, tokens and connection strings go **only** in `*.sops.yaml` files (`secret.sops.yaml`, `configmap.sops.yaml`)
+- Never inline a credential in `helmrelease.yaml`, `helm-values.yaml`, a plain `configmap.yaml`, or an env var default
 
 ### Before Any Change
 1. This is a **LIVE cluster** - every merge affects production
@@ -124,7 +130,7 @@ For each PR, investigate:
    - Check if new secrets are required
 
 4. **Check Kubernetes version requirements:**
-   - If the update requires a newer K8s version than v1.33.x → **FLAG AS BLOCKED**
+   - If the update requires a newer K8s version than v1.35.x → **FLAG AS BLOCKED**
    - Do NOT recommend merging
 
 #### Step 4: Present Findings and Ask for Consent
@@ -273,8 +279,9 @@ Present the created files for review before committing. Ask: **"Here are the fil
 - **Node IP:** 192.168.100.180
 - **Pod CIDR:** 10.42.0.0/16
 - **Service CIDR:** 10.24.0.0/16
-- **Ingress External:** 192.168.100.91
-- **Ingress Internal:** Uses internal DNS
+- **Ingress External:** 192.168.100.92 (`external-ingress-nginx-controller`, `network`)
+- **Ingress Internal:** 192.168.100.91 (`internal-ingress-nginx-controller`, `network`)
+- **Envoy Gateway:** 192.168.100.90 (`nextjs-envoy`, `envoy-gateway-system`) - GatewayClass `eg`, used by `nextjs-adapter-test` only for now
 
 ### Ingress Classes
 - `external` - Public-facing via Cloudflare tunnel
@@ -332,10 +339,11 @@ spec:
     substitute:
       APP: *app
       APP_PVC: *app  # Or custom PVC name if different
+      MOVER_UID: "1000"      # MUST match the app's runAsUser
+      MOVER_FSGROUP: "1000"  # MUST match the app's fsGroup
     substituteFrom:
       - kind: Secret
-        name: volsync-secret
-        namespace: volsync-system
+        name: volsync-secret  # NO namespace field - see below
 ```
 
 2. Add to `app/kustomization.yaml`:
@@ -343,6 +351,16 @@ spec:
 components:
   - ../../../../flux/components/volsync
 ```
+
+**`substituteFrom` secrets must live in the Kustomization's OWN namespace.** Flux ignores a `namespace:`
+field under `postBuild.substituteFrom` - it always resolves the Secret in `metadata.namespace` of the
+Kustomization. So an app in `default` needs `volsync-secret` in `default`, not in `volsync-system`.
+
+**`MOVER_UID`/`MOVER_FSGROUP` are mandatory whenever the app does not run as UID 568.** The volsync
+component defaults to `568`; if the app writes its PVC as a different UID the mover cannot read the data,
+restic still writes a snapshot, and the **backup is silently incomplete**. Check the app's
+`podSecurityContext` before enabling VolSync, and verify with `status.lastSyncTime` on the
+ReplicationSource - a `Ready` Kustomization proves nothing.
 
 **Backup schedule:** Every 6 hours
 **Retention:** 6 hourly, 7 daily, 4 weekly, 3 monthly
@@ -360,19 +378,23 @@ All tools are managed via `mise` and available in the project environment:
 | Tool | Version | Purpose |
 |------|---------|---------|
 | `kubectl` | 1.32.1 | Kubernetes cluster management |
-| `flux` | 2.6.4 | GitOps operations |
-| `helm` | 4.0.5 | Helm chart management |
-| `helmfile` | 1.2.3 | Declarative Helm deployments |
-| `sops` | 3.11.0 | Secret encryption/decryption |
+| `flux` | 2.9.4 | GitOps operations |
+| `helm` | 4.2.3 | Helm chart management |
+| `helmfile` | 1.7.3 | Declarative Helm deployments |
+| `sops` | 3.13.3 | Secret encryption/decryption |
 | `age` | 1.3.1 | Encryption backend for SOPS |
-| `talosctl` | 1.10.7 | Talos node management |
-| `talhelper` | 3.1.2 | Talos config generation |
+| `talosctl` | 1.13.7 | Talos node management |
+| `talhelper` | 3.1.16 | Talos config generation |
 | `kustomize` | 5.6.0 | Kustomization builds |
-| `kubeconform` | 0.7.0 | YAML validation |
-| `task` | 3.46.4 | Task runner |
-| `yq` | 4.50.1 | YAML processing |
+| `kubeconform` | 0.8.0 | YAML validation |
+| `task` | 3.52.0 | Task runner |
+| `yq` | 4.53.3 | YAML processing |
 | `jq` | 1.7.1 | JSON processing |
-| `cloudflared` | 2026.1.1 | Cloudflare tunnel CLI |
+| `cloudflared` | 2026.7.3 | Cloudflare tunnel CLI |
+| `uv` | 0.12.3 | Python package/tool runner |
+
+Source of truth is `.mise.toml`; run `mise ls --current` to confirm. Note `kubectl` (1.32.1) lags the
+live cluster (v1.35.0) - fine for most operations, but expect skew warnings.
 
 ## Common Operations
 

--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -47,6 +47,8 @@ spec:
               requests:
                 memory: 2G
                 cpu: 2000m
+              limits:
+                memory: 8Gi
         pod:
           runtimeClassName: nvidia
     service:

--- a/kubernetes/apps/cert-manager/cert-manager/app/helm-values.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helm-values.yaml
@@ -8,3 +8,14 @@ prometheus:
   enabled: true
   servicemonitor:
     enabled: true
+resources:
+  requests:
+    memory: 48Mi
+webhook:
+  resources:
+    requests:
+      memory: 48Mi
+cainjector:
+  resources:
+    requests:
+      memory: 96Mi

--- a/kubernetes/apps/databases/clickhouse/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/clickhouse/app/helmrelease.yaml
@@ -44,6 +44,11 @@ spec:
               readiness: *probes
             securityContext:
               privileged: true
+            resources:
+              requests:
+                memory: 1Gi
+              limits:
+                memory: 8Gi
             ports:
               - name: http
                 containerPort: 8123

--- a/kubernetes/apps/databases/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/helmrelease.yaml
@@ -24,6 +24,9 @@ spec:
   values:
     crds:
       create: true
+    resources:
+      requests:
+        memory: 160Mi
     monitoring:
       podMonitorEnabled: true
       grafanaDashboard:

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
@@ -6,6 +6,7 @@ metadata:
   name: postgres17
 spec:
   instances: 1
+  enablePDB: false # single node: PDB guarantees nothing, only deadlocks drains
   imageName: ghcr.io/cloudnative-pg/postgresql:17.2-32
   primaryUpdateStrategy: unsupervised
   storage:
@@ -43,7 +44,7 @@ spec:
       endpointURL: http://192.168.100.63:9000
       # Note: serverName version needs to be inclemented
       # when recovering from an existing cnpg cluster
-      serverName: &currentCluster postgres16
+      serverName: &currentCluster postgres17
       s3Credentials:
         accessKeyId:
           name: cloudnative-pg-secret

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster17.yaml
+  - ./scheduledbackup.yaml
   - ./service.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres17-daily
+spec:
+  # CNPG uses a 6-field cron (seconds first): daily at midnight
+  schedule: "0 0 0 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: postgres17

--- a/kubernetes/apps/databases/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster.yaml
@@ -23,13 +23,3 @@ spec:
       cpu: 100m
     limits:
       memory: 4096Mi
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchExpressions:
-              - key: app
-                operator: In
-                values:
-                  - dragonfly

--- a/kubernetes/apps/default/cliproxy/ks.yaml
+++ b/kubernetes/apps/default/cliproxy/ks.yaml
@@ -29,6 +29,9 @@ spec:
     substitute:
       APP: *app
       APP_PVC: *app
+      MOVER_UID: "1000"
+      MOVER_GID: "1000"
+      MOVER_FSGROUP: "1000"
     substituteFrom:
       - kind: Secret
         name: volsync-secret

--- a/kubernetes/apps/default/error-pages/app/helmrelease.yaml
+++ b/kubernetes/apps/default/error-pages/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
   values:
     controllers:
       error-pages:
-        replicas: 2
+        replicas: 1
         pod:
           imagePullSecrets:
             - name: docker-regcred

--- a/kubernetes/apps/default/nas-download/app/helmrelease.yaml
+++ b/kubernetes/apps/default/nas-download/app/helmrelease.yaml
@@ -30,6 +30,12 @@ spec:
               - -c
               - |
                 mkdir -p /tmp/nginx_temp/client_temp /tmp/nginx_temp/proxy_temp /tmp/nginx_temp/fastcgi_temp /tmp/nginx_temp/uwsgi_temp /tmp/nginx_temp/scgi_temp && chmod -R 777 /tmp/nginx_temp
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
         containers:
           app:
             image:
@@ -40,6 +46,12 @@ spec:
               - nginx
               - -g
               - daemon off;
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 256Mi
         pod:
           securityContext:
             runAsUser: 0

--- a/kubernetes/apps/default/pelican/app/helmrelease.yaml
+++ b/kubernetes/apps/default/pelican/app/helmrelease.yaml
@@ -49,6 +49,10 @@ spec:
                   name: pelican-secret
             securityContext:
               privileged: true
+            resources:
+              requests:
+                cpu: 25m
+                memory: 320Mi
     service:
       pelican:
         controller: pelican

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
               TZ: Europe/Bucharest
               QBT_WEBUI_PORT: &port 80
               QBT_TORRENTING_PORT: &bittorrentPort 50413
-              QBT_Application__MemoryWorkingSetLimit: 10000
+              QBT_Application__MemoryWorkingSetLimit: 3500
               QBT_Preferences__WebUI__AlternativeUIEnabled: false
               QBT_Preferences__WebUI__AuthSubnetWhitelistEnabled: true
               QBT_Preferences__WebUI__AuthSubnetWhitelist: |-
@@ -66,7 +66,7 @@ spec:
                 cpu: 100m
                 memory: 1Gi
               limits:
-                memory: 10Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -79,7 +79,7 @@ spec:
                 cpu: 100m
                 memory: 1Gi
               limits:
-                memory: 12Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/envoyproxy.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/config/app/envoyproxy.yaml
@@ -10,7 +10,7 @@ spec:
     kubernetes:
       envoyDeployment:
         name: nextjs-envoy
-        replicas: 2
+        replicas: 1
         container:
           resources:
             requests:
@@ -22,13 +22,6 @@ spec:
         pod:
           labels:
             nextjs.davidilie.dev/gateway: shared
-          topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: kubernetes.io/hostname
-              whenUnsatisfiable: ScheduleAnyway
-              labelSelector:
-                matchLabels:
-                  nextjs.davidilie.dev/gateway: shared
       envoyService:
         name: nextjs-envoy
         type: LoadBalancer
@@ -36,9 +29,6 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: nextjs-adapter-test.davidhome.ro,nextjs-control.davidhome.ro
           lbipam.cilium.io/ips: 192.168.100.90
-      envoyPDB:
-        name: nextjs-envoy
-        minAvailable: 1
       envoyServiceAccount:
         name: nextjs-envoy
   telemetry:

--- a/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app/helmrelease.yaml
+++ b/kubernetes/apps/envoy-gateway-system/envoy-gateway/controller/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
     crds:
       enabled: true
     deployment:
-      replicas: 2
+      replicas: 1
       envoyGateway:
         resources:
           requests:
@@ -33,15 +33,5 @@ spec:
             memory: 256Mi
           limits:
             memory: 1Gi
-      pod:
-        topologySpreadConstraints:
-          - maxSkew: 1
-            topologyKey: kubernetes.io/hostname
-            whenUnsatisfiable: ScheduleAnyway
-            labelSelector:
-              matchLabels:
-                control-plane: envoy-gateway
-    podDisruptionBudget:
-      minAvailable: 1
     service:
       type: ClusterIP

--- a/kubernetes/apps/infastructure/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/infastructure/go2rtc/app/helmrelease.yaml
@@ -57,6 +57,8 @@ spec:
               requests:
                 cpu: 10m
                 memory: 256Mi
+              limits:
+                memory: 1Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/infastructure/portainer/app/helmrelease.yaml
+++ b/kubernetes/apps/infastructure/portainer/app/helmrelease.yaml
@@ -18,6 +18,10 @@ spec:
         name: portainer
         namespace: flux-system
   values:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
     persistence:
       enabeld: true
       size: 1G

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -46,10 +46,25 @@ spec:
         prometheus:
           serviceMonitor:
             enabled: true
+        resources:
+          requests:
+            memory: 48Mi
       ui:
         enabled: true
         rollOutPods: true
+        backend:
+          resources:
+            requests:
+              memory: 32Mi
+        frontend:
+          resources:
+            requests:
+              memory: 32Mi
         ingress:
           enabled: true
           className: internal
           hosts: ["hubble.davidhome.ro"]
+    operator:
+      resources:
+        requests:
+          memory: 160Mi

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -22,6 +22,9 @@ spec:
       repository: nvcr.io/nvidia/k8s-device-plugin
       tag: v0.19.3
     runtimeClassName: nvidia
+    resources:
+      requests:
+        memory: 32Mi
     nodeSelector:
       nvidia.feature.node.kubernetes.io/gpu: "true"
     # Time-slicing: advertise the single RTX 2080 as 4 schedulable

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -28,3 +28,7 @@ spec:
       podMonitor:
         enabled: true
         namespace: "{{ .Release.Namespace }}"
+      deployment:
+        resources:
+          requests:
+            memory: 128Mi

--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -27,5 +27,8 @@ spec:
     controller:
       serviceMonitor:
         create: true
+      resources:
+        requests:
+          memory: 32Mi
     webhook:
       enabled: false

--- a/kubernetes/apps/network/external/external-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/external/external-dns/helmrelease.yaml
@@ -41,6 +41,10 @@ spec:
       - --events
       - --ignore-ingress-tls-spec
       - --ingress-class=external
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
     policy: sync
     sources: ["crd", "ingress"]
     txtPrefix: k8s.

--- a/kubernetes/apps/network/internal/external-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/external-dns/helmrelease.yaml
@@ -53,6 +53,14 @@ spec:
             port: http-webhook
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
     policy: sync
     sources: ["service", "ingress"]
     domainFilters: ["davidhome.ro"]

--- a/kubernetes/apps/nextjs-adapter-test/platform/app/control.yaml
+++ b/kubernetes/apps/nextjs-adapter-test/platform/app/control.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: nextjs-control
 spec:
-  replicas: 3
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -112,13 +112,6 @@ spec:
         - name: tmp
           emptyDir: {}
       terminationGracePeriodSeconds: 45
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: nextjs-control
 ---
 apiVersion: v1
 kind: Service
@@ -134,13 +127,3 @@ spec:
       port: 3000
       targetPort: http
       protocol: TCP
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: nextjs-control
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: nextjs-control

--- a/kubernetes/apps/observability/cloudflare-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/cloudflare-exporter/app/helmrelease.yaml
@@ -29,6 +29,10 @@ spec:
         value: Europe/Bucharest
       - name: FREE_TIER
         value: "true"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
     serviceMonitor:
       enabled: true
   interval: 10m0s

--- a/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/fluent-bit/app/helmrelease.yaml
@@ -104,6 +104,12 @@ spec:
           compress gzip
           log_response_payload false
 
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
     serviceMonitor:
       enabled: true
     logLevel: warn

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -25,6 +25,10 @@ spec:
   values:
     deploymentStrategy:
       type: Recreate
+    resources:
+      requests:
+        cpu: 25m
+        memory: 256Mi
     admin:
       existingSecret: grafana-admin-secret
     env:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -73,6 +73,10 @@ spec:
             memory: 6Gi
     prometheus-node-exporter:
       fullnameOverride: node-exporter
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
       prometheus:
         monitor:
           enabled: true
@@ -84,6 +88,10 @@ spec:
               targetLabel: kubernetes_node
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
       metricLabelsAllowlist:
         - pods=[*]
         - deployments=[*]

--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -55,6 +55,10 @@ spec:
                 enabled: true
             securityContext:
               readOnlyRootFilesystem: true
+            resources:
+              requests:
+                cpu: 50m
+                memory: 768Mi
         pod:
           terminationGracePeriodSeconds: 1
           securityContext:

--- a/kubernetes/apps/observability/plausible/clickhouse/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/clickhouse/helmrelease.yaml
@@ -48,6 +48,15 @@ spec:
               - name: metrics
                 containerPort: 9363
                 protocol: TCP
+            # Was BestEffort with an empty resources block — 132 restarts with
+            # exit 137. The limit also caps ClickHouse's own cgroup-derived
+            # max_server_memory_usage instead of it sizing against node RAM.
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
     persistence:
       event-data:
         enabled: true

--- a/kubernetes/apps/observability/posthog/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/posthog/app/helmrelease.yaml
@@ -125,13 +125,16 @@ spec:
                   periodSeconds: 15
                   timeoutSeconds: 10
                   failureThreshold: 80
-            # No memory cap — node is beefy, let posthog burst freely.
             # Request kept modest so the pod schedules on a node that's
-            # already heavily committed; bursts use spare CPU/RAM.
+            # already heavily committed; bursts use spare CPU/RAM. Capped at
+            # 6Gi so an unbounded web burst can't push the node into a
+            # Talos OOMController SIGKILL of unrelated cgroups.
             resources:
               requests:
                 cpu: 1500m
                 memory: 2Gi
+              limits:
+                memory: 6Gi
       worker:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -145,12 +148,15 @@ spec:
               SKIP_ASYNC_MIGRATIONS_SETUP: "0"
               AUTO_START_ASYNC_MIGRATIONS: "1"
             envFrom: *envFrom
-            # No cap — celery memory grows with task variety (async migrations,
-            # batch exports, hog functions); let it use the box.
+            # Celery memory grows with task variety (async migrations, batch
+            # exports, hog functions), so the cap is generous — but it is a
+            # cap: uncapped it was a top contributor to node-wide OOM kills.
             resources:
               requests:
                 cpu: 1000m
                 memory: 3Gi
+              limits:
+                memory: 8Gi
       plugins:
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
       retries: 3
   values:
     fullnameOverride: smartctl-exporter
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
     serviceMonitor:
       enabled: true
     prometheusRules:

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -39,6 +39,11 @@ spec:
       localpv:
         image:
           registry: quay.io/
+        resources:
+          requests:
+            memory: 32Mi
+          limits:
+            memory: 256Mi
       helperPod:
         image:
           registry: quay.io/

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -11,3 +11,6 @@ spec:
   interval: 1h
   values:
     replicaCount: 1
+    resources:
+      requests:
+        memory: 192Mi


### PR DESCRIPTION
Wave 1 of the 2026-08-09 cluster audit. All changes were implemented and adversarially reviewed (chart-rendered per pinned version) before this PR; reviewer verdict SHIP-WITH-NOTES.

## What this does
- **C1 (OOM pressure):** memory requests for ~30 BestEffort pods; caps runaway limits (sabnzbd 12→4Gi, qbittorrent 10→4Gi + `QBT MemoryWorkingSetLimit` 10000→3500, ollama 8Gi, go2rtc 1Gi, posthog web/worker 6/8Gi). Node requests go 68%→~74% after right-sizing the ClickHouse requests down per review.
- **C2 (no restore point):** `ScheduledBackup` `postgres17-daily` (immediate + nightly), fixes `serverName: postgres16→postgres17`, `enablePDB: false`.
- **C4 (silent backup failure):** cliproxy volsync `MOVER_UID/GID/FSGROUP: 1000` (was defaulting to 568 against a UID-1000 PVC — failing since Aug 6).
- **C5 (drain deadlock):** replicas→1 and PDB/topologySpread/antiAffinity removal for envoy-gateway controller+proxy, nextjs-control, error-pages, dragonfly.
- **4G:** CLAUDE.md corrected (Talos v1.12.x / K8s v1.35.x, ingress IPs, volsync docs, onedr0p reference).

## Expected effect on merge
Pods with changed resources restart (rolling). Reviewer confirmed both tuppr CRs are `Completed` at current versions, so the tuppr restart is a no-op — **no drain is triggered**.

## Post-merge manual steps
1. `kubectl delete replicationsource cliproxy -n default` — the stuck `SyncInProgress` state won't clear on its own; Flux recreates it and the first sync should complete with the new UID.
2. Verify base backup: `kubectl get backups -n databases` shows a completed backup, then check `s3://home-cluster-pg/postgres17/` in MinIO.
3. Delete the two out-of-band `nextjs-adapter-test-*-pdb` objects (they exist only in the cluster, not git).
4. Later, in a window: kubelet `systemReserved`/`kubeReserved`/`evictionHard` in the Talos patch (machine config apply — deliberately not in this PR).
5. MinIO: the orphaned `postgres16/` WAL prefix is no longer retention-managed; clean it up manually.