### PR TITLE
backup(portainer): enable VolSync

### DIFF
--- a/kubernetes/apps/infastructure/portainer/app/kustomization.yaml
+++ b/kubernetes/apps/infastructure/portainer/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+components:
+  - ../../../../flux/components/volsync

--- a/kubernetes/apps/infastructure/portainer/ks.yaml
+++ b/kubernetes/apps/infastructure/portainer/ks.yaml
@@ -6,6 +6,9 @@ metadata:
   name: &app portainer
   namespace: &namespace infastructure
 spec:
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
   targetNamespace: *namespace
   commonMetadata:
     labels:
@@ -20,3 +23,13 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      APP_PVC: portainer
+      MOVER_UID: "0"
+      MOVER_GID: "0"
+      MOVER_FSGROUP: "0"
+    substituteFrom:
+      - kind: Secret
+        name: volsync-secret


### PR DESCRIPTION
## What
- enable the repository-standard VolSync component for Portainer
- back up the existing `portainer` PVC with root ownership matching the container
- make Portainer reconciliation depend on VolSync

## Validation
- `kubectl kustomize kubernetes/apps/infastructure/portainer/app`
- flux-local v8.4.0: Portainer Kustomization and HelmRelease checks passed
- full run: 198 passed; unrelated Grafana Helm repository refresh timed out at flux-local's fixed 60-second limit (reproduced in an isolated retry)