### PR TITLE
feat(auth): prepare DavidApps regional identity foundation

### DIFF
--- a/docs/runbooks/davidapps-native-oidc.md
+++ b/docs/runbooks/davidapps-native-oidc.md
@@ -1,0 +1,109 @@
+# Home applications: native DavidApps sign-in
+
+This change prepares native OIDC for Grafana, Paperless-ngx, Open WebUI, and
+qui. It is not deployable while any OIDC Secret has the annotation
+`davidapps.dev/credentials: pending-provisioning`. The encrypted values in
+those Secrets are deliberate placeholders, not usable clients.
+
+Each application keeps its existing local login during the canary. Do not add
+an ingress authentication boundary to these hosts: the application should own
+its local roles, sessions, API keys, and recovery login.
+
+## Dedicated clients
+
+Provision four OIDC applications with `setup_app`. Every application uses
+`signupPolicy: closed` and a `standard` confidential client. Grant users access
+in DavidApps; a person who merely has a DavidApps account does not gain access.
+
+| Application | Hostname | Exact redirect URI |
+| --- | --- | --- |
+| Grafana | `monitoring.davidapps.dev` | `https://monitoring.davidapps.dev/login/generic_oauth` |
+| Paperless-ngx | `paperless.davidhome.ro` | `https://paperless.davidhome.ro/accounts/oidc/davidapps/login/callback/` |
+| Open WebUI | `chat.davidhome.ro` | `https://chat.davidhome.ro/oauth/oidc/callback` |
+| qui | `qui.davidhome.ro` | `https://qui.davidhome.ro/api/auth/oidc/callback` |
+
+Use one application and one client per row. Supply the row's URI through
+`oidcRedirectUris`; do not reuse a client between hosts. Standard clients use
+PKCE S256, `client_secret_basic`, pairwise `sub`, and EdDSA/Ed25519 ID tokens.
+
+Capture each returned client ID and one-time client secret directly into its
+encrypted file:
+
+| Application | Encrypted file |
+| --- | --- |
+| Grafana | `kubernetes/apps/observability/grafana/app/oidc-secret.sops.yaml` |
+| Paperless-ngx | `kubernetes/apps/default/paperless/app/oidc-secret.sops.yaml` |
+| Open WebUI | `kubernetes/apps/ai/open-webui/app/oidc-secret.sops.yaml` |
+| qui | `kubernetes/apps/downloads/qui/app/oidc-secret.sops.yaml` |
+
+Edit with SOPS using the home-cluster age identity. Never decrypt to a tracked
+file, paste a secret into a prompt, or put a secret in a shell argument. For
+Paperless, replace the client ID and secret inside the encrypted JSON value.
+After replacement, change the unencrypted annotation to
+`davidapps.dev/credentials: provisioned` and verify there are no remaining
+`pending-provisioning` annotations before opening a deployment PR.
+
+## Application behavior
+
+### Grafana
+
+Grafana Generic OAuth requests `openid profile email offline_access`, verifies
+the EdDSA ID token against DavidApps JWKS, and uses PKCE S256. The pairwise
+`sub` is the login key. A new account starts with Grafana's default Viewer
+role; `skip_org_role_sync` preserves later local role changes.
+
+Basic authentication and the login form remain enabled. Keep the existing
+admin Secret. Do not enable automatic provider redirect during the canary.
+
+### Paperless-ngx
+
+The unsafe `PAPERLESS_AUTO_LOGIN_USERNAME=admin` setting is removed. The
+allauth provider explicitly enables PKCE, uses `sub` as its account ID, and
+sends the client secret with HTTP Basic authentication. Regular Paperless
+login remains enabled.
+
+Before the first direct DavidApps sign-in, log in as the existing Paperless
+administrator, open **My Profile**, and connect the DavidApps provider. This
+links the external subject to the existing administrator instead of creating
+a second administrator. Later granted users may create minimal, non-admin
+Paperless rows through social signup; Paperless continues to own document
+permissions and API tokens.
+
+### Open WebUI
+
+Open WebUI uses discovery, explicit PKCE S256, and pairwise `sub`. OAuth
+settings stay environment-authoritative. Password authentication and the local
+login form remain enabled, automatic redirect stays off, and email-based
+account merging stays off.
+
+The existing local administrator is the recovery account. A first OIDC login
+does not silently inherit it. Review the new local user's Open WebUI role after
+the first login; do not grant administrator through identity claims.
+
+### qui
+
+qui discovers DavidApps from the issuer and automatically adds PKCE S256 when
+the provider advertises it. Its exact callback is configured explicitly.
+Built-in username/password login stays visible and machine API keys continue
+to work.
+
+Before considering removal of built-in login, inspect
+`/api/auth/oidc/config` in an authenticated test and confirm the authorization
+URL contains both `code_challenge` and `code_challenge_method=S256`.
+
+## Canary and rollback
+
+Roll out one application at a time, beginning with Grafana or qui. For every
+host, test:
+
+1. a private-window sign-in by a granted account;
+2. refusal of a signed-in DavidApps account without the app grant;
+3. a granted friend, if applicable, receiving only the intended local role;
+4. logout and a second private-window sign-in;
+5. the local recovery administrator;
+6. existing API keys, service accounts, mobile clients, or automations.
+
+Do not disable a local login or force OIDC redirect until two independent
+private-window sign-ins and the app's machine-client tests pass. Rollback is a
+revert of the individual HelmRelease OIDC settings; local accounts and API
+credentials remain unchanged.

--- a/docs/runbooks/home-assistant-davidapps-oidc.md
+++ b/docs/runbooks/home-assistant-davidapps-oidc.md
@@ -1,0 +1,97 @@
+# Home Assistant: Sign in with DavidApps
+
+The Romania Home Assistant instance is an appliance at `192.168.30.10`.
+Kubernetes only publishes `https://hass.davidhome.ro`; it cannot install a
+custom component or edit the appliance's `/config` directory. Complete this
+runbook in Home Assistant after provisioning its dedicated DavidApps client.
+
+Do not add ingress authentication annotations. Home Assistant mobile clients,
+websockets, webhooks, and API tokens must continue to reach Home Assistant
+directly. The built-in Home Assistant username/password provider stays enabled
+as the recovery path.
+
+## 1. Provision the dedicated client
+
+Create an OIDC-mode DavidApps application for the single hostname
+`hass.davidhome.ro` with:
+
+- callback: `https://hass.davidhome.ro/auth/oidc/callback`
+- compatibility: `standard` (PKCE S256 remains required)
+- signup policy: `closed`
+
+Use `oidcRedirectUris` when calling `setup_app`; the usual DavidApps callback
+paths alone are not the Home Assistant callback. Store the returned one-time
+client secret directly in the Home Assistant secret store. Do not reuse the UK
+Home Assistant client: DavidApps identity is pairwise, one host per client.
+
+Grant the intended people access to this application in DavidApps before they
+try to sign in. The Home Assistant component cannot reliably reject a new user
+late in its own account-creation flow, so the DavidApps application grant is
+the registration boundary.
+
+## 2. Install the component on the appliance
+
+In HACS, install **OpenID Connect/SSO Authentication** from
+`christiaangoossens/hass-oidc-auth`. Select release `v1.1.1` or the exact newer
+release that has been reviewed before deployment. Release `v1.1.1` requires
+Home Assistant 2025.11 or newer.
+
+If HACS is unavailable, download the `v1.1.1` release asset
+`hass-oidc-auth.zip`, verify SHA-256
+`9ce9e6153f80c781e360b93e097ff7d87d09235430fc48e7a67d97dda5fc3322`,
+and extract its contents to `/config/custom_components/auth_oidc/`.
+
+## 3. Configure Home Assistant
+
+Add the one-time secret to `/config/secrets.yaml` without copying it into Git:
+
+```yaml
+davidapps_oidc_client_secret: "<value from DavidApps>"
+```
+
+Add this block to `/config/configuration.yaml`:
+
+```yaml
+auth_oidc:
+  client_id: "<Romania Home Assistant client ID>"
+  client_secret: !secret davidapps_oidc_client_secret
+  discovery_url: "https://id.davidapps.dev/.well-known/openid-configuration"
+  display_name: "DavidApps"
+  id_token_signing_alg: "EdDSA"
+  additional_scopes:
+    - email
+  claims:
+    display_name: name
+    username: email
+  features:
+    automatic_user_linking: false
+    automatic_person_creation: true
+    disable_rfc7636: false
+    include_groups_scope: false
+    force_https: true
+    default_redirect: false
+```
+
+Do not add an `auth_providers` block that removes `homeassistant`. Do not turn
+on automatic user linking: matching an OIDC email to an existing local name can
+silently inherit that local account's privileges and bypass its MFA.
+
+## 4. Validate and roll out
+
+1. Run Home Assistant's configuration check, then restart Home Assistant.
+2. In a private browser window, confirm both **DavidApps** and the alternative
+   built-in login are offered; there must be no forced redirect.
+3. Sign in as a person who has the DavidApps application grant. Confirm the
+   callback returns to `hass.davidhome.ro` and creates a separate, non-admin
+   Home Assistant user.
+4. From an existing local administrator session, promote that new Home
+   Assistant user only if it actually needs administrator rights.
+5. Confirm a signed-in DavidApps account without an application grant is
+   refused before Home Assistant creates a user.
+6. Test the Home Assistant mobile app, a websocket dashboard, an existing
+   webhook, and an existing long-lived API token.
+7. Confirm the existing local administrator can still sign in directly.
+
+To roll back, remove the `auth_oidc` block and restart Home Assistant. The
+built-in provider remains available throughout; removing the custom component
+can wait until after the local login has been verified.

--- a/docs/runbooks/home-assistant-davidapps-oidc.md
+++ b/docs/runbooks/home-assistant-davidapps-oidc.md
@@ -12,16 +12,22 @@ as the recovery path.
 
 ## 1. Provision the dedicated client
 
-Create an OIDC-mode DavidApps application for the single hostname
+The OIDC-mode DavidApps application is provisioned for the single hostname
 `hass.davidhome.ro` with:
 
 - callback: `https://hass.davidhome.ro/auth/oidc/callback`
 - compatibility: `standard` (PKCE S256 remains required)
 - signup policy: `closed`
 
+Its public client ID is `yLE1m6fYPNo3b6YJZrvdiBbqGFQdqy51`. The one-time
+client secret is staged in macOS Keychain service
+`dev.davidapps.auth.oidc.home-assistant-home`, under that client ID, until the
+appliance configuration is complete. Delete that Keychain item after both the
+DavidApps login and built-in recovery login are proven.
+
 Use `oidcRedirectUris` when calling `setup_app`; the usual DavidApps callback
-paths alone are not the Home Assistant callback. Store the returned one-time
-client secret directly in the Home Assistant secret store. Do not reuse the UK
+paths alone are not the Home Assistant callback. Transfer the staged one-time
+client secret directly into the Home Assistant secret store. Do not reuse the UK
 Home Assistant client: DavidApps identity is pairwise, one host per client.
 
 Grant the intended people access to this application in DavidApps before they

--- a/docs/runbooks/portainer-davidapps-oauth.md
+++ b/docs/runbooks/portainer-davidapps-oauth.md
@@ -11,7 +11,7 @@ internal authentication alongside external auth.
 
 ## Provision the client
 
-Create a dedicated OIDC-mode DavidApps application:
+The dedicated OIDC-mode DavidApps application is provisioned:
 
 - name: `Portainer home`
 - hostname: `portainer.davidhome.ro`
@@ -19,13 +19,19 @@ Create a dedicated OIDC-mode DavidApps application:
 - signup policy: `closed`
 - compatibility: `legacy_confidential`
 
+Its public client ID is `NAoG3FkofGiO_39SKa5QYhux3LrH8XfO`. The one-time
+client secret is staged in macOS Keychain service
+`dev.davidapps.auth.oidc.portainer`, under that client ID. Read it only while
+entering the settings below, then delete the Keychain item after both OAuth
+and initial-administrator recovery are proven.
+
 Portainer Custom OAuth does not send PKCE. `legacy_confidential` is the narrow
 DavidApps exception for an older confidential server client: authorization
 code only, no refresh or client-credentials grant, and only `openid profile
 email`. Do not provision Portainer as a standard client and do not reuse this
 exception for applications that support PKCE.
 
-Enter the one-time secret directly into Portainer. It belongs in the encrypted
+Enter the staged one-time secret directly into Portainer. It belongs in the encrypted
 Portainer database/backup, not a Kubernetes Secret or this public repository.
 
 ## Configure Portainer
@@ -33,18 +39,18 @@ Portainer database/backup, not a Kubernetes Secret or this public repository.
 While signed in as the initial administrator, open **Settings →
 Authentication**, select **OAuth**, choose **Custom**, and enter:
 
-| Field | Value |
-| --- | --- |
-| Client ID | dedicated Portainer client ID |
-| Client secret | one-time Portainer client secret |
-| Authorization URL | `https://id.davidapps.dev/api/auth/oauth2/authorize` |
-| Access token URL | `https://id.davidapps.dev/api/auth/oauth2/token` |
-| Resource URL | `https://id.davidapps.dev/api/auth/oauth2/userinfo` |
-| Redirect URL | `https://portainer.davidhome.ro` |
-| Logout URL | `https://id.davidapps.dev/api/auth/oauth2/end-session` |
-| User identifier | `sub` |
-| Scopes | `openid profile email` |
-| Auth Style | credentials in the authorization header |
+| Field             | Value                                                  |
+| ----------------- | ------------------------------------------------------ |
+| Client ID         | dedicated Portainer client ID                          |
+| Client secret     | one-time Portainer client secret                       |
+| Authorization URL | `https://id.davidapps.dev/api/auth/oauth2/authorize`   |
+| Access token URL  | `https://id.davidapps.dev/api/auth/oauth2/token`       |
+| Resource URL      | `https://id.davidapps.dev/api/auth/oauth2/userinfo`    |
+| Redirect URL      | `https://portainer.davidhome.ro`                       |
+| Logout URL        | `https://id.davidapps.dev/api/auth/oauth2/end-session` |
+| User identifier   | `sub`                                                  |
+| Scopes            | `openid profile email`                                 |
+| Auth Style        | credentials in the authorization header                |
 
 Enable **Use SSO** and **Automatic user provisioning**. Leave **Hide internal
 authentication prompt** off. Leave automatic team membership and automatic

--- a/docs/runbooks/portainer-davidapps-oauth.md
+++ b/docs/runbooks/portainer-davidapps-oauth.md
@@ -1,0 +1,71 @@
+# Portainer: DavidApps OAuth
+
+Portainer stores external-authentication settings in its own database, not in
+GitOps. The home-cluster change first converts the Portainer Service from the
+chart's default `NodePort` to `ClusterIP`, so the internal ingress is the only
+published HTTP path. This does not alter Portainer Agent connections.
+
+Do not enable OAuth until the ClusterIP change is rendered and deployed. Keep
+the initial Portainer administrator: Portainer allows that one account to use
+internal authentication alongside external auth.
+
+## Provision the client
+
+Create a dedicated OIDC-mode DavidApps application:
+
+- name: `Portainer home`
+- hostname: `portainer.davidhome.ro`
+- exact redirect URI: `https://portainer.davidhome.ro`
+- signup policy: `closed`
+- compatibility: `legacy_confidential`
+
+Portainer Custom OAuth does not send PKCE. `legacy_confidential` is the narrow
+DavidApps exception for an older confidential server client: authorization
+code only, no refresh or client-credentials grant, and only `openid profile
+email`. Do not provision Portainer as a standard client and do not reuse this
+exception for applications that support PKCE.
+
+Enter the one-time secret directly into Portainer. It belongs in the encrypted
+Portainer database/backup, not a Kubernetes Secret or this public repository.
+
+## Configure Portainer
+
+While signed in as the initial administrator, open **Settings →
+Authentication**, select **OAuth**, choose **Custom**, and enter:
+
+| Field | Value |
+| --- | --- |
+| Client ID | dedicated Portainer client ID |
+| Client secret | one-time Portainer client secret |
+| Authorization URL | `https://id.davidapps.dev/api/auth/oauth2/authorize` |
+| Access token URL | `https://id.davidapps.dev/api/auth/oauth2/token` |
+| Resource URL | `https://id.davidapps.dev/api/auth/oauth2/userinfo` |
+| Redirect URL | `https://portainer.davidhome.ro` |
+| Logout URL | `https://id.davidapps.dev/api/auth/oauth2/end-session` |
+| User identifier | `sub` |
+| Scopes | `openid profile email` |
+| Auth Style | credentials in the authorization header |
+
+Enable **Use SSO** and **Automatic user provisioning**. Leave **Hide internal
+authentication prompt** off. Leave automatic team membership and automatic
+administrator assignment off because DavidApps does not issue Portainer team
+claims. Grant app admission in DavidApps, then assign Portainer environment and
+team permissions locally.
+
+The identifier must remain `sub`. DavidApps subjects are pairwise and opaque;
+email is display/contact data, not the durable Portainer identity key.
+
+## Validate and roll back
+
+1. Confirm the rendered Service type is `ClusterIP` and no Portainer NodePort
+   remains.
+2. In a private window, sign in as a granted account and confirm Portainer
+   creates a non-admin user with no unintended environment access.
+3. Confirm an ungranted DavidApps account is rejected before provisioning.
+4. Grant the new Portainer user only the intended environments or teams.
+5. Confirm the initial administrator can still use internal authentication.
+6. Confirm the home and UK Portainer Agents remain connected.
+
+If the OAuth round trip fails, return to the initial administrator session and
+select internal authentication or correct the custom provider settings. Do not
+hide the internal prompt until recovery has been tested from a second browser.

--- a/docs/runbooks/portainer-davidapps-oauth.md
+++ b/docs/runbooks/portainer-davidapps-oauth.md
@@ -47,7 +47,7 @@ Authentication**, select **OAuth**, choose **Custom**, and enter:
 | Access token URL  | `https://id.davidapps.dev/api/auth/oauth2/token`       |
 | Resource URL      | `https://id.davidapps.dev/api/auth/oauth2/userinfo`    |
 | Redirect URL      | `https://portainer.davidhome.ro`                       |
-| Logout URL        | `https://id.davidapps.dev/api/auth/oauth2/end-session` |
+| Logout URL        | leave blank                                            |
 | User identifier   | `sub`                                                  |
 | Scopes            | `openid profile email`                                 |
 | Auth Style        | credentials in the authorization header                |
@@ -57,6 +57,11 @@ authentication prompt** off. Leave automatic team membership and automatic
 administrator assignment off because DavidApps does not issue Portainer team
 claims. Grant app admission in DavidApps, then assign Portainer environment and
 team permissions locally.
+
+Portainer 2.39.6 sends its configured logout URL as a bare request without an
+`id_token_hint`; DavidApps correctly rejects that request. Leaving the field
+blank signs out of Portainer without presenting a broken identity-provider
+logout flow.
 
 The identifier must remain `sub`. DavidApps subjects are pairwise and opaque;
 email is display/contact data, not the durable Portainer identity key.

--- a/docs/runbooks/proxmox-davidapps-oidc.md
+++ b/docs/runbooks/proxmox-davidapps-oidc.md
@@ -1,0 +1,84 @@
+# Proxmox Nucleus: DavidApps OpenID realm
+
+Kubernetes only publishes `https://nucleus.davidhome.ro`; the OpenID realm is
+configured on the Proxmox appliance. Do not put an ingress authentication
+boundary around Proxmox: API tokens, noVNC/SPICE, websockets, and direct
+`:8006` recovery must retain Proxmox authentication.
+
+Keep `root@pam`, the built-in `pve` realm, and direct LAN access throughout the
+canary.
+
+## Compatibility preflight
+
+On Nucleus, record `pveversion -v` before making a realm change. Proxmox VE 9's
+Trixie OpenID stack uses `proxmox-openid` 1.x with `openidconnect` 4: it sends
+PKCE S256 and accepts EdDSA with an Ed25519/OKP JWKS key. If Nucleus reports an
+older or locally replaced OpenID stack, stop and test its algorithm support
+before creating the client.
+
+Also confirm both discovery and JWKS are reachable from the appliance:
+
+```text
+https://id.davidapps.dev/.well-known/openid-configuration
+https://id.davidapps.dev/api/auth/jwks
+```
+
+Do not disable TLS verification.
+
+## Provision the client
+
+Create a dedicated OIDC-mode DavidApps application:
+
+- name: `Proxmox Nucleus`
+- hostname: `nucleus.davidhome.ro`
+- exact redirect URI: `https://nucleus.davidhome.ro`
+- signup policy: `closed`
+- compatibility: `standard`
+
+The client is confidential, requires PKCE S256, and receives a pairwise
+subject for this host. Enter the one-time client key directly into the Proxmox
+realm form; do not place it in GitOps, a shell argument, or command history.
+
+## Create the realm
+
+In **Datacenter → Permissions → Realms → Add → OpenID Connect Server**, set:
+
+| Field | Value |
+| --- | --- |
+| Realm | `davidapps` |
+| Issuer URL | `https://id.davidapps.dev` |
+| Client ID | dedicated Nucleus client ID |
+| Client Key | one-time Nucleus client secret |
+| Username Claim | `subject` |
+| Scopes | `email profile` |
+| Autocreate Users | enabled |
+| Query userinfo endpoint | enabled |
+| Verify TLS certificate | enabled |
+| Default realm | disabled during canary |
+| Groups Claim / Autocreate Groups | empty / disabled |
+
+Proxmox automatically includes the `openid` scope. `subject` maps DavidApps
+pairwise `sub` to an opaque `<subject>@davidapps` user. Do not use email as the
+durable username and do not map administrator access from an identity claim.
+
+Autocreation is safe only with the DavidApps application grant in front of it.
+After the first successful login, place the created Proxmox user in an
+explicit local group and attach the minimum ACL role it needs. A granted friend
+can therefore manage only selected VMs or pools without gaining access to the
+rest of Nucleus.
+
+## Validate and roll back
+
+1. Open a private browser at `https://nucleus.davidhome.ro`, select the
+   `davidapps` realm, and sign in with a granted account.
+2. Confirm the request uses PKCE S256 and the returned account is the expected
+   opaque subject in the `davidapps` realm.
+3. Before assigning an ACL, confirm the new user has no administrative access.
+4. Assign a minimal local group/ACL and verify only those resources appear.
+5. Confirm an ungranted DavidApps account is rejected.
+6. Test console websocket, an existing API token, and the ingress hostname.
+7. Sign in through direct `https://<nucleus-lan-ip>:8006` as `root@pam`.
+
+If the new realm fails, keep using `pam`/`pve` and remove or disable only the
+`davidapps` realm. The existing users, ACLs, API tokens, and direct recovery
+path are independent of it.

--- a/docs/runbooks/proxmox-davidapps-oidc.md
+++ b/docs/runbooks/proxmox-davidapps-oidc.md
@@ -5,6 +5,13 @@ configured on the Proxmox appliance. Do not put an ingress authentication
 boundary around Proxmox: API tokens, noVNC/SPICE, websockets, and direct
 `:8006` recovery must retain Proxmox authentication.
 
+This integration is staged but blocked. Do not create the realm until the
+DavidApps ID token and userinfo response include a stable
+`preferred_username` claim and the identity-platform release containing it is
+live. Proxmox requires a username claim; the pairwise `sub` remains the durable
+external identity but is not exposed through the realm form as a usable
+username mapping today.
+
 Keep `root@pam`, the built-in `pve` realm, and direct LAN access throughout the
 canary.
 
@@ -45,7 +52,7 @@ The client is confidential, requires PKCE S256, and receives a pairwise
 subject for this host. Enter the staged one-time client key directly into the Proxmox
 realm form; do not place it in GitOps, a shell argument, or command history.
 
-## Create the realm
+## Create the realm after the blocker is cleared
 
 In **Datacenter → Permissions → Realms → Add → OpenID Connect Server**, set:
 
@@ -55,7 +62,7 @@ In **Datacenter → Permissions → Realms → Add → OpenID Connect Server**, 
 | Issuer URL                       | `https://id.davidapps.dev`     |
 | Client ID                        | dedicated Nucleus client ID    |
 | Client Key                       | one-time Nucleus client secret |
-| Username Claim                   | `subject`                      |
+| Username Claim                   | `preferred_username`           |
 | Scopes                           | `email profile`                |
 | Autocreate Users                 | enabled                        |
 | Query userinfo endpoint          | enabled                        |
@@ -63,9 +70,10 @@ In **Datacenter → Permissions → Realms → Add → OpenID Connect Server**, 
 | Default realm                    | disabled during canary         |
 | Groups Claim / Autocreate Groups | empty / disabled               |
 
-Proxmox automatically includes the `openid` scope. `subject` maps DavidApps
-pairwise `sub` to an opaque `<subject>@davidapps` user. Do not use email as the
-durable username and do not map administrator access from an identity claim.
+Proxmox automatically includes the `openid` scope. The username claim is for
+the local realm account name; DavidApps still binds the session to the
+pairwise, opaque `sub`. Do not use email as the durable username and do not map
+administrator access from an identity claim.
 
 Autocreation is safe only with the DavidApps application grant in front of it.
 After the first successful login, place the created Proxmox user in an

--- a/docs/runbooks/proxmox-davidapps-oidc.md
+++ b/docs/runbooks/proxmox-davidapps-oidc.md
@@ -27,7 +27,7 @@ Do not disable TLS verification.
 
 ## Provision the client
 
-Create a dedicated OIDC-mode DavidApps application:
+The dedicated OIDC-mode DavidApps application is provisioned:
 
 - name: `Proxmox Nucleus`
 - hostname: `nucleus.davidhome.ro`
@@ -35,27 +35,33 @@ Create a dedicated OIDC-mode DavidApps application:
 - signup policy: `closed`
 - compatibility: `standard`
 
+Its public client ID is `SCD6q5kyLgkLMudY7rzAMGTqADrepzEc`. The one-time
+client secret is staged in macOS Keychain service
+`dev.davidapps.auth.oidc.proxmox-nucleus`, under that client ID. Do not install
+the realm until the version/EdDSA check above passes. Delete the Keychain item
+only after the new realm and PAM/PVE recovery have both been tested.
+
 The client is confidential, requires PKCE S256, and receives a pairwise
-subject for this host. Enter the one-time client key directly into the Proxmox
+subject for this host. Enter the staged one-time client key directly into the Proxmox
 realm form; do not place it in GitOps, a shell argument, or command history.
 
 ## Create the realm
 
 In **Datacenter → Permissions → Realms → Add → OpenID Connect Server**, set:
 
-| Field | Value |
-| --- | --- |
-| Realm | `davidapps` |
-| Issuer URL | `https://id.davidapps.dev` |
-| Client ID | dedicated Nucleus client ID |
-| Client Key | one-time Nucleus client secret |
-| Username Claim | `subject` |
-| Scopes | `email profile` |
-| Autocreate Users | enabled |
-| Query userinfo endpoint | enabled |
-| Verify TLS certificate | enabled |
-| Default realm | disabled during canary |
-| Groups Claim / Autocreate Groups | empty / disabled |
+| Field                            | Value                          |
+| -------------------------------- | ------------------------------ |
+| Realm                            | `davidapps`                    |
+| Issuer URL                       | `https://id.davidapps.dev`     |
+| Client ID                        | dedicated Nucleus client ID    |
+| Client Key                       | one-time Nucleus client secret |
+| Username Claim                   | `subject`                      |
+| Scopes                           | `email profile`                |
+| Autocreate Users                 | enabled                        |
+| Query userinfo endpoint          | enabled                        |
+| Verify TLS certificate           | enabled                        |
+| Default realm                    | disabled during canary         |
+| Groups Claim / Autocreate Groups | empty / disabled               |
 
 Proxmox automatically includes the `openid` scope. `subject` maps DavidApps
 pairwise `sub` to an opaque `<subject>@davidapps` user. Do not use email as the

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
             image:
               repository: ghcr.io/home-operations/postgres-init
               tag: 18.4
-            envFrom: &envFrom
+            envFrom:
               - secretRef:
                   name: openwebui
         containers:
@@ -76,7 +76,40 @@ spec:
                 value: "32"
               - name: ENABLE_MEMORIES
                 value: "true"
-            envFrom: *envFrom
+              # DavidApps OIDC (local password login remains available)
+              - name: WEBUI_URL
+                value: https://chat.davidhome.ro
+              - name: ENABLE_OAUTH
+                value: "true"
+              - name: ENABLE_OAUTH_PERSISTENT_CONFIG
+                value: "false"
+              - name: ENABLE_OAUTH_SIGNUP
+                value: "true"
+              - name: ENABLE_PASSWORD_AUTH
+                value: "true"
+              - name: ENABLE_LOGIN_FORM
+                value: "true"
+              - name: OAUTH_AUTO_REDIRECT
+                value: "false"
+              - name: OAUTH_MERGE_ACCOUNTS_BY_EMAIL
+                value: "false"
+              - name: OPENID_PROVIDER_URL
+                value: https://id.davidapps.dev/.well-known/openid-configuration
+              - name: OPENID_REDIRECT_URI
+                value: https://chat.davidhome.ro/oauth/oidc/callback
+              - name: OAUTH_PROVIDER_NAME
+                value: DavidApps
+              - name: OAUTH_SCOPES
+                value: openid profile email
+              - name: OAUTH_CODE_CHALLENGE_METHOD
+                value: S256
+              - name: OAUTH_SUB_CLAIM
+                value: sub
+            envFrom:
+              - secretRef:
+                  name: openwebui
+              - secretRef:
+                  name: open-webui-oidc-secret
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/open-webui/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./claim.yaml
   - ./secret.sops.yaml
+  - ./oidc-secret.sops.yaml
   - ./helmrelease.yaml
 components:
   - ../../../../flux/components/volsync

--- a/kubernetes/apps/ai/open-webui/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/ai/open-webui/app/oidc-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: open-webui-oidc-secret
+  annotations:
+    davidapps.dev/credentials: pending-provisioning
+type: Opaque
+stringData:
+  OAUTH_CLIENT_ID: ENC[AES256_GCM,data:1tdWCGGmGPZHhreYjewdd1vQcT89m+vEB9cdn4gdXgFvqBJ5TDKt800gchOu,iv:OzlINgQZs2zpqrsp6t6qMGOjDv3njCLwol2L4DrPqjY=,tag:L9aBlGDUTRMZR8RozK60TQ==,type:str]
+  OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:5euh5tJ9d0MWCxnIF9xgs19ATBgq+ZartPYTNbYc8prVXch77XPSF2cLP3/TRA0YEg==,iv:gWh/XZr5Zwyksd34WP2vWRFaK+Bh4vV8K30OqTNGB7s=,tag:mHfl4RwC05q2GHAku5Tu2Q==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2SnVrOUcvVUJzV0tYKy8z
+        akVHTFdxUVN5Q1psRTdIai9weEtVTDB3d0ZJCnZ0S2xTTGhtM0duOGdPQWZLdU5h
+        NE1JU245cE41R3NhMEk1U0dsclVRU2sKLS0tIFVRT1g2aFlrYmZsclRDMno3UHl1
+        U3BqSkpCNldJWXVSZVV4dG03aWd1bzgKAJQLpkPP18dYeC8a4/EMu/w3AJJ3W5pw
+        8LUsKN8eO5CjWOTNLxtuT0DPWe06cOzGXKTlIJ0tk5CMAAAAGpzUVw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-14T14:34:42Z"
+  mac: ENC[AES256_GCM,data:9Mz6Ci1/N8ODEJgPfgXGp3CRHBCqXxKqjbsHJzlR7N+sapV0MwlJbAvVARQBN47t/IaLflv9/Dz0iLzptYD29/ksATR593lLZwBUaYvKh3tXvL+uV9QW6tEbI7HXVjbM1UP9BLyyUTY+HahKLx3UT82xBVDG+nZ6E0jBaAEckDw=,iv:qKsaUlFfmHEIJu4M5rwHEVVlwMSGjQVRd2/fv+64k6s=,tag:+TabZggCGYhz0/Ufy+sv0A==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/ai/open-webui/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/ai/open-webui/app/oidc-secret.sops.yaml
@@ -3,24 +3,24 @@ kind: Secret
 metadata:
   name: open-webui-oidc-secret
   annotations:
-    davidapps.dev/credentials: pending-provisioning
+    davidapps.dev/credentials: provisioned
 type: Opaque
 stringData:
-  OAUTH_CLIENT_ID: ENC[AES256_GCM,data:1tdWCGGmGPZHhreYjewdd1vQcT89m+vEB9cdn4gdXgFvqBJ5TDKt800gchOu,iv:OzlINgQZs2zpqrsp6t6qMGOjDv3njCLwol2L4DrPqjY=,tag:L9aBlGDUTRMZR8RozK60TQ==,type:str]
-  OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:5euh5tJ9d0MWCxnIF9xgs19ATBgq+ZartPYTNbYc8prVXch77XPSF2cLP3/TRA0YEg==,iv:gWh/XZr5Zwyksd34WP2vWRFaK+Bh4vV8K30OqTNGB7s=,tag:mHfl4RwC05q2GHAku5Tu2Q==,type:str]
+  OAUTH_CLIENT_ID: ENC[AES256_GCM,data:wS5mM9eqXxMRRb2Xffnt9eVg/qjqnXGNv1W8IcSiNws=,iv:kqGExz5/3LOoJggpYxhjQT8pIJ2wwD8V26Q3xcsGQ0Q=,tag:2uP2EbHELl0Kj/i0UZA4hA==,type:str]
+  OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:PC7f+Gr73gEPHifuRwNiZLH9G/3LCi8MFpb/hwKv+nc7S0+Tkn1ZOrCGJg==,iv:UW7p2m1LBP0SR4wOPtNlehJN69+LvtHVVmuEScRk5bQ=,tag:6loE/oQWe3eMBMaZpQwKPg==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2SnVrOUcvVUJzV0tYKy8z
-        akVHTFdxUVN5Q1psRTdIai9weEtVTDB3d0ZJCnZ0S2xTTGhtM0duOGdPQWZLdU5h
-        NE1JU245cE41R3NhMEk1U0dsclVRU2sKLS0tIFVRT1g2aFlrYmZsclRDMno3UHl1
-        U3BqSkpCNldJWXVSZVV4dG03aWd1bzgKAJQLpkPP18dYeC8a4/EMu/w3AJJ3W5pw
-        8LUsKN8eO5CjWOTNLxtuT0DPWe06cOzGXKTlIJ0tk5CMAAAAGpzUVw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTWjAyV1NMRG1RZDZYaGZu
+        QjZwOTQvRXFWcnlEendpNElzNkhxbXNIcFJZCnNHQlozMjIwbVVJSEx2RDVHUnB1
+        UFN3TUdnRndVVEN0LzNTL0lkUWd2VkEKLS0tIHNkQTZjYlJpQVFmTUNEeVp5YTM3
+        elFTUFdhMWxoZkRrZFNPemxkRFBWRVUK1cELnWTwuSWjTVETDiNjUD8gyY4zRRTH
+        mNvXQuYISTTm8nJ0ovXq7X0mw+8iFHCHFoR1AeweqHAzyRl+CaA5xQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T14:34:42Z"
-  mac: ENC[AES256_GCM,data:9Mz6Ci1/N8ODEJgPfgXGp3CRHBCqXxKqjbsHJzlR7N+sapV0MwlJbAvVARQBN47t/IaLflv9/Dz0iLzptYD29/ksATR593lLZwBUaYvKh3tXvL+uV9QW6tEbI7HXVjbM1UP9BLyyUTY+HahKLx3UT82xBVDG+nZ6E0jBaAEckDw=,iv:qKsaUlFfmHEIJu4M5rwHEVVlwMSGjQVRd2/fv+64k6s=,tag:+TabZggCGYhz0/Ufy+sv0A==,type:str]
+  lastmodified: "2026-08-14T14:53:42Z"
+  mac: ENC[AES256_GCM,data:B6u/eNN39iTwBe3+jrjZO2vpAr3QiUO1LhUuJr5KqlE9hrq9SuIPsjYtfJBj3uTq+412CnEvssuednpNoMar9S5dIm0rH/k9hjSxKTjgKt4Z03/2/2YM2YcCn9qCXsKh2pfD5zbaE+ryHBFpm35F3gpMWt7+40sKR6dUsURjeIg=,iv:73NTgD3jACq0v1ml2soPqzUDo5GZw+X9gANBM9RtuRA=,tag:e3xQVJkvNQeS9lEI2IltOw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/auth/davidapps-gate/DEPLOYMENT-READINESS.md
+++ b/kubernetes/apps/auth/davidapps-gate/DEPLOYMENT-READINESS.md
@@ -1,0 +1,24 @@
+# DavidApps regional checker readiness
+
+This Kustomization is intentionally not ready to deploy as committed.
+
+Before merging it into the live branch:
+
+1. Replace the gate image placeholder with the digest produced by the current
+   `davidapps-auth` release.
+2. Replace every value in `secret.sops.yaml` with real encrypted material. The
+   database URL must use the dedicated read-only gate role. The shared keys
+   must match the identity platform, while the gate seed must be unique to
+   `gate-home`.
+3. Put the CA that signed the database server certificate in the same Secret.
+   The URL already requires `sslmode=verify-full` and points pgx at the mounted
+   CA file.
+4. Verify that `identity-db.davidapps.dev` resolves to the private central
+   database load balancer and is reachable from the home node
+   (`192.168.100.180`) on TCP 5432. The central load balancer/firewall must
+   restrict that listener to the expected regional source addresses.
+5. Prove `/healthz`, `/readyz`, public JWKS retrieval, revocation polling, and
+   one complete login round trip before adding nginx auth annotations to apps.
+
+The local Dragonfly is deliberately ephemeral and reachable only by the gate
+pod. It stores replay state, not identity data.

--- a/kubernetes/apps/auth/davidapps-gate/app/dragonfly.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/dragonfly.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: davidapps-replay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: davidapps-replay
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: davidapps-replay
+        app.kubernetes.io/part-of: davidapps-auth
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dragonfly
+          image: ghcr.io/dragonflydb/dragonfly:v1.40.1@sha256:ebf3c6c213e82fb51b4521660cca13f06f3421dc5b1ed14f2f474c50b5e29986
+          imagePullPolicy: IfNotPresent
+          args:
+            - --logtostderr
+            - --bind=0.0.0.0
+            - --port=6379
+            - --maxmemory=256mb
+            - --cache_mode=true
+            - --dir=/tmp
+            - --dbfilename=
+            - --proactor_threads=1
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 384Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: davidapps-replay
+spec:
+  selector:
+    app.kubernetes.io/name: davidapps-replay
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP

--- a/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
@@ -31,14 +31,21 @@ spec:
         - name: gate
           # Keep the regional checker pinned to the same released gate build as
           # the central identity platform.
-          image: ghcr.io/davidilie/davidapps-auth-gate:main-11@sha256:51bd268b9b4e9de4c55b019762385f20727af11fcfabcdd8e7b9c6ce037d7ed0
+          image: ghcr.io/davidilie/davidapps-auth-gate:main-12@sha256:7aecb2c61263b94dd13b15aa5c9ddb800543a4d30c35de72671cc016239721d5
           imagePullPolicy: IfNotPresent
           env:
             - name: DATABASE_URL
+              value: postgresql://identity-db.davidapps.dev:5432/davidapps_auth?sslmode=verify-full&sslrootcert=/etc/davidapps/db-ca/ca.crt
+            - name: PGUSER
               valueFrom:
                 secretKeyRef:
                   name: davidapps-gate-config
-                  key: DATABASE_URL
+                  key: PGUSER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: davidapps-gate-config
+                  key: PGPASSWORD
             - name: GATE_ED25519_SEED
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: davidapps-gate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: davidapps-gate
+  template:
+    metadata:
+      annotations:
+        reloader.stakater.com/auto: "true"
+      labels:
+        app.kubernetes.io/name: davidapps-gate
+        app.kubernetes.io/part-of: davidapps-auth
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: docker-regcred
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gate
+          # DEPLOYMENT BLOCKER: replace this old central-cluster image with the
+          # digest produced by the current davidapps-auth release.
+          image: ghcr.io/davidilie/davidapps-auth-gate:main-2@sha256:58650f5b1acbe6add5d56149d3ca84824af4c9949ca3d8caeea5a2dbbf5a4aa3
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: davidapps-gate-config
+                  key: DATABASE_URL
+            - name: GATE_ED25519_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: davidapps-gate-config
+                  key: GATE_ED25519_SEED
+            - name: HANDOFF_STATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: davidapps-gate-config
+                  key: HANDOFF_STATE_KEY
+            - name: REVOCATION_HMAC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: davidapps-gate-config
+                  key: REVOCATION_HMAC_KEY
+            - name: SHARE_LINK_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: davidapps-gate-config
+                  key: SHARE_LINK_SIGNING_KEY
+            - name: DRAGONFLY_URL
+              value: redis://davidapps-replay.auth.svc.cluster.local:6379/0
+            - name: GATE_ED25519_KEY_ID
+              value: gate-home-v1
+            - name: HANDOFF_JWKS_URL
+              value: https://id.davidapps.dev/api/auth/jwks
+            - name: REVOCATION_GATE_ID
+              value: gate-home
+            - name: REVOCATION_POLL_URL
+              value: https://id.davidapps.dev/internal/revocations
+            - name: SHARE_LINK_KEY_ID
+              value: prod-v1
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: database-ca
+              mountPath: /etc/davidapps/db-ca
+              readOnly: true
+      volumes:
+        - name: database-ca
+          secret:
+            secretName: davidapps-gate-config
+            defaultMode: 0444
+            items:
+              - key: ca.crt
+                path: ca.crt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: davidapps-gate
+spec:
+  selector:
+    app.kubernetes.io/name: davidapps-gate
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
@@ -29,8 +29,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: gate
-          # DEPLOYMENT BLOCKER: replace this old central-cluster image with the
-          # digest produced by the current davidapps-auth release.
+          # Keep the regional checker pinned to the same released gate build as
+          # the central identity platform.
           image: ghcr.io/davidilie/davidapps-auth-gate:main-11@sha256:51bd268b9b4e9de4c55b019762385f20727af11fcfabcdd8e7b9c6ce037d7ed0
           imagePullPolicy: IfNotPresent
           env:

--- a/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
@@ -31,7 +31,7 @@ spec:
         - name: gate
           # DEPLOYMENT BLOCKER: replace this old central-cluster image with the
           # digest produced by the current davidapps-auth release.
-          image: ghcr.io/davidilie/davidapps-auth-gate:main-2@sha256:58650f5b1acbe6add5d56149d3ca84824af4c9949ca3d8caeea5a2dbbf5a4aa3
+          image: ghcr.io/davidilie/davidapps-auth-gate:main-11@sha256:51bd268b9b4e9de4c55b019762385f20727af11fcfabcdd8e7b9c6ce037d7ed0
           imagePullPolicy: IfNotPresent
           env:
             - name: DATABASE_URL

--- a/kubernetes/apps/auth/davidapps-gate/app/kustomization.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./dragonfly.yaml
+  - ./gate.yaml
+  - ./networkpolicy.yaml

--- a/kubernetes/apps/auth/davidapps-gate/app/networkpolicy.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/networkpolicy.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: davidapps-gate
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: davidapps-gate
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+      ports:
+        - port: 8080
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: davidapps-replay
+      ports:
+        - port: 6379
+          protocol: TCP
+    # Standard NetworkPolicy cannot select an FQDN. The central database load
+    # balancer must separately restrict TCP 5432 by regional source address.
+    - ports:
+        - port: 5432
+          protocol: TCP
+    # Public JWKS and revocation polling both use HTTPS.
+    - ports:
+        - port: 443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: davidapps-replay
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: davidapps-replay
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: davidapps-gate
+      ports:
+        - port: 6379
+          protocol: TCP
+  egress: []

--- a/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
@@ -4,12 +4,13 @@ metadata:
   name: davidapps-gate-config
 type: Opaque
 stringData:
-  DATABASE_URL: ENC[AES256_GCM,data:Eo5ZaWWfrEoc2Nz5VCJRChRUzA1Vsvjd0fy9Lkt1fvwwSfgIBQgnPSDpeXeMiBkxA5ANp8jfksMHZbxZVAaWCo3qliUpTFl0bQGUjqxhuon0+LakhaEnqdo3LCBJHH1lzom2LdnIAMJ5sWVK8mpZP+0jwvLOGRCZOmgl68Lxg73aLT9hpJrclzSfybH/0DGjQOppfCULIEADSrzjlKZo8sckF7OocFWSQ5zbmykgEBipTL03Jpn4Pm7OVhTKzZ7e5jh0FvM9rGA=,iv:Sfy/kH1nj7EYCYL2insPGKOqi79v69vJGH5fnAO5N48=,tag:mLyo2TjrtBt1MGlQQdlMRQ==,type:str]
   HANDOFF_STATE_KEY: ENC[AES256_GCM,data:74gmaNmcCpc1Yzez9ZfKh42fujEO+MkFZVSqk6yZv+Td3PCN3BVm/L1dZWYuiWKKZjgABaC8BNpQatpIiWq/8Q==,iv:iGQNowJfzh8MnVvJhlUrcuLS4eiSTRAoFiIuqEymGZs=,tag:+9dlahaCcyXd04xtCvlQAg==,type:str]
   REVOCATION_HMAC_KEY: ENC[AES256_GCM,data:oyepzKxsOvUeaCOOohZcdTG7ogCdNfRRkpPR1dnHys96Xz+N4Egzs7kSETA8gM1hgJyVmNHzGivH6HXHivtFmQ==,iv:v4IXYAFdPfyMh4z0gucMB2IcyYbJAFHT541LtfsV1UE=,tag:5myCQpgQRqGyK1EfyiOjXg==,type:str]
   SHARE_LINK_SIGNING_KEY: ENC[AES256_GCM,data:YzOFPtTONyJnGBjGoyVBTghPDq5JuKkNo5OWp/VomfZztb3zLue3Rhxbki/3VjxYTSasw+0heGOc0V8nyXOmVQ==,iv:qJUW/qikWik6Q1fKYxhtTdGOXma0sHimoLYG28VLyxA=,tag:r0WlkRjHVRaxzmMTc2zXgQ==,type:str]
   GATE_ED25519_SEED: ENC[AES256_GCM,data:LFquHW6HLI7A5zokMtZ5AOvOycPdzEP4fSSNaJC0VXf5zB58ZTLMzUQhXdQ=,iv:1XuFl0895KMb6hcvDNj9Qv4nIQTIVJDHaQcbHvLwNUw=,tag:S4VTlKfOQcOBM6Rt4hnqcQ==,type:str]
   ca.crt: ENC[AES256_GCM,data:TMqdABOa370MOv2oyoChC2SC21B9iRgO3SsgPifQqknC5vfN0hIaN8qoIgk428MrFOuSzvgufrcFIezuGpi7QG03wPYg026ZmrcN6WdfwXEJW4mLGq/tRXn0va9LzmA1fqlDEvj+nXGVuLwb46CSuzMlwG9zQkGimzINklkSj50Ll/v3NiQjXMaP1Kug0EX3ufBv5ZvJfcb8D5WklT0G0XXPe1/md8ZdAu3dXYx4AOowkmkkxri7dGHsnEP8Pv+SZiQxGhzShT9Djz6E3c5K0y5BApwPb7LscsCwduWkyp2CjYQXlJ78EylTr3/5skLvvwg6QNVzOyvbGleR5vSfc4yOb/FDhqp6gblUuVuxKzppKYBndU30oejjU4zPulzzOeD5lUTv1teL7m2Lf05aWrpvH5ol8GLpwYHOX/CPJuT6+ATr2N6m9SimLSCgLNgBAefLYXDsP4ojWhZ9/2ST+Ph4KnInT0q6TfUvvATPBgGl4NMZCqtYzzpDHRiJDYgkig5dveb97YzEEldcOCtkHb87Ui32DXo6dzYg5neSmI0Sp8hKQQmCmdZ2VCiJ+NdzF1IK9uFexr2A6ZY/nRabu1yf2htOJiQGvDqUzTtQaBdz6b7NxMw7ZIaARIrPJHur0Mv/FFY7vWKTX0hdbMlu6+BvHNgoB6pPQmqbJOS3aFI8XEmriJsV0QGxnborfc1ySVrQYVCUsC6cDjY/+MK6DkNqjkEYYEhzIUc20GFlr9nDtqe7kVW+kIXjaXcinlECoZ/M+TU/FQRC/YgfplLHtIVfAjiswqQLUg1U2iYhuAhpHWZClyCWWLGTRZJHw67ccMXwWfUOOAIjFSUauYakXvs15wJTCCdP0pMJjhd8VuBvdLlkyRlP2fQgOkgh4M9UE4lwTreWpx3SgVOBAsFt,iv:MFse+DAzp2pnmCirr1ufhjgGAtQyCPUXHevEnM8vDu4=,tag:WB2IBSUpvjRCxS8idl8suQ==,type:str]
+  PGUSER: ENC[AES256_GCM,data:1Fopk7xrocO7o1SK4GU=,iv:izTi1/ymW78FfTF2hzeZ7+UNZHIGvjiPOkImXeTnkt8=,tag:e4+F37lsCAjSZLcNAX3Asg==,type:str]
+  PGPASSWORD: ENC[AES256_GCM,data:cQOcwQr7bmfDaMF+8b72E1PKFfy6l40YasNOg3Mf90F2FTX4cC9YrMnjDbTWwBQE1QJT7LL+k9ZDCXzeGKewSM2K,iv:csxuUn0+JqEzgzhZChdjvlLTYFOXHtuIZ84VqPkUzis=,tag:O43pJXAVyAZ+ljLi09hjzQ==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -21,8 +22,8 @@ sops:
         ZnQ2MnRuQnlFVTNpWmx6MGpLMXpRRmcK5OPsi3bqaxqMkys93RamygBw9m6KbWwu
         KasQhlh9OBh0WjtXrKmaAvm8VUTwg7EExRc72CnMRIxSE8Aiy4xLPQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T14:50:45Z"
-  mac: ENC[AES256_GCM,data:kbKif4LUVq2W8eBW0F91RpS2NziWGQ+Dk0BnIjaCTjOoiXqVdt+Nks8n0Pmi3fj9ku+XMzgFI5xSOzldfYlq7ZjP5JPXQwSra54wNWJ52wJqPm3RjzYyqgPILELSDWQQSWrnfuc4E7YNPIYDrOVaEXdrthftf3qr2BCMIe678Nc=,iv:CCH9Z3xKxs3FtOxYWzngKTidWMYq3Ov5U5K7GTI7J08=,tag:F6ipKzhMvYGo+otyqaFNoQ==,type:str]
+  lastmodified: "2026-08-14T16:14:24Z"
+  mac: ENC[AES256_GCM,data:q6UbPccV8FiR6F3rC2sKcg6BLV7IrIfk787U5+DFGJXjYzlmkJLb1qz6TM+KXW7F/k7M/91WwsfeLO75aZGu28q8BNJys/JofcTjqIyJicNUdE7taCb/ymLVipQTIQVCSmN+p5tMniqV1vpBshtJAU4qM9FeuU5MtIVUhP8G3VY=,iv:mYFpzz0UGVHRhytf55Z3HRVhFvl30hJ+4sNCCiZh3D4=,tag:KJXZEo9WQqQMw/w6t3TBaQ==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
@@ -1,30 +1,28 @@
-# DEPLOYMENT BLOCKER: encrypted placeholders only. Replace all six values with
-# production material before this Kustomization reaches the live branch.
 apiVersion: v1
 kind: Secret
 metadata:
   name: davidapps-gate-config
 type: Opaque
 stringData:
-  DATABASE_URL: ENC[AES256_GCM,data:R0ufgROYs1pUrJVN7E75BGwz5qN+NBx7QtFF3RpFV0dErFfGfnP4L8U63tTn0JpQXJ76CSlRzztvTpAGCw2t45sS/RXWaQDzLrHAD2GGXPFgM/amKwru9e04f5lwk2nBSMQXOmXNbrNpd6k/HEuVvsWxuDIwDs6t8Im6Qxv+uDkpBPjlhWhRj3S5igTONF1gLWPvOBZ44xq3zJpRXxbEpfn4,iv:CfzRF8lEvSF/ckDjW13PpE0M1bvxLW2XMe+QckSlvdc=,tag:eslkX6AP0+DArfmFwXbgtw==,type:str]
-  HANDOFF_STATE_KEY: ENC[AES256_GCM,data:HzYFTLFjUbsY8+6xWz+G7SuG/7OUQP7ibtBaUoi9DWzLjdA+6TKCFO1yBN0=,iv:lumgOQYfZ2D26y9QhBAHHEEmOOGMTuk6V9haEbfDv6k=,tag:RYVvWSeg7r2LfpEbRnUgAw==,type:str]
-  REVOCATION_HMAC_KEY: ENC[AES256_GCM,data:8yqna1l7dh1oFEF7XJuIO1oq5W6WDLqK5JexqJzOK0Bdn558BExGSsU+04/UCA==,iv:u0wiGz3WRLVLaBVthNAuk0Z7hIzW/cbYM1+Hz9unXCk=,tag:vuTX7EcNC8hl4xI2BGDIow==,type:str]
-  SHARE_LINK_SIGNING_KEY: ENC[AES256_GCM,data:g0ivZ2bxF5fVb7uEI88cppLPn6FItXwrJ9VJ1nJbcK3nR/eGNaRoT1YB4KjAaRZjug==,iv:Kc8eyLkoryjI0QZpGQxleGttCxtDytgYfnTkLCCWKOc=,tag:1TKcVl8YM61reHZ+2JKsLg==,type:str]
-  GATE_ED25519_SEED: ENC[AES256_GCM,data:4in4bCEY6HfBko3kq7W9ndBIiSe4p90mIvWsOLAvYKtqrENQn1KunOw=,iv:qr+LH3VRJJxqN3LZo1jrI/b0R9kb+Vbp2TkFccYYbqI=,tag:Mqb6oDkA82bQfY9mlxqG4A==,type:str]
-  ca.crt: ENC[AES256_GCM,data:sc9q6N7jFfuZ1dlhSZrA6zvkLzXSOIATEqFi1g==,iv:HceBrD/MPe4SmPGOjUA0r/FspAVelLjWvxvO1MSmY18=,tag:LMbWgc5PLXI94DuasjgN/g==,type:str]
+  DATABASE_URL: ENC[AES256_GCM,data:Eo5ZaWWfrEoc2Nz5VCJRChRUzA1Vsvjd0fy9Lkt1fvwwSfgIBQgnPSDpeXeMiBkxA5ANp8jfksMHZbxZVAaWCo3qliUpTFl0bQGUjqxhuon0+LakhaEnqdo3LCBJHH1lzom2LdnIAMJ5sWVK8mpZP+0jwvLOGRCZOmgl68Lxg73aLT9hpJrclzSfybH/0DGjQOppfCULIEADSrzjlKZo8sckF7OocFWSQ5zbmykgEBipTL03Jpn4Pm7OVhTKzZ7e5jh0FvM9rGA=,iv:Sfy/kH1nj7EYCYL2insPGKOqi79v69vJGH5fnAO5N48=,tag:mLyo2TjrtBt1MGlQQdlMRQ==,type:str]
+  HANDOFF_STATE_KEY: ENC[AES256_GCM,data:74gmaNmcCpc1Yzez9ZfKh42fujEO+MkFZVSqk6yZv+Td3PCN3BVm/L1dZWYuiWKKZjgABaC8BNpQatpIiWq/8Q==,iv:iGQNowJfzh8MnVvJhlUrcuLS4eiSTRAoFiIuqEymGZs=,tag:+9dlahaCcyXd04xtCvlQAg==,type:str]
+  REVOCATION_HMAC_KEY: ENC[AES256_GCM,data:oyepzKxsOvUeaCOOohZcdTG7ogCdNfRRkpPR1dnHys96Xz+N4Egzs7kSETA8gM1hgJyVmNHzGivH6HXHivtFmQ==,iv:v4IXYAFdPfyMh4z0gucMB2IcyYbJAFHT541LtfsV1UE=,tag:5myCQpgQRqGyK1EfyiOjXg==,type:str]
+  SHARE_LINK_SIGNING_KEY: ENC[AES256_GCM,data:YzOFPtTONyJnGBjGoyVBTghPDq5JuKkNo5OWp/VomfZztb3zLue3Rhxbki/3VjxYTSasw+0heGOc0V8nyXOmVQ==,iv:qJUW/qikWik6Q1fKYxhtTdGOXma0sHimoLYG28VLyxA=,tag:r0WlkRjHVRaxzmMTc2zXgQ==,type:str]
+  GATE_ED25519_SEED: ENC[AES256_GCM,data:LFquHW6HLI7A5zokMtZ5AOvOycPdzEP4fSSNaJC0VXf5zB58ZTLMzUQhXdQ=,iv:1XuFl0895KMb6hcvDNj9Qv4nIQTIVJDHaQcbHvLwNUw=,tag:S4VTlKfOQcOBM6Rt4hnqcQ==,type:str]
+  ca.crt: ENC[AES256_GCM,data:TMqdABOa370MOv2oyoChC2SC21B9iRgO3SsgPifQqknC5vfN0hIaN8qoIgk428MrFOuSzvgufrcFIezuGpi7QG03wPYg026ZmrcN6WdfwXEJW4mLGq/tRXn0va9LzmA1fqlDEvj+nXGVuLwb46CSuzMlwG9zQkGimzINklkSj50Ll/v3NiQjXMaP1Kug0EX3ufBv5ZvJfcb8D5WklT0G0XXPe1/md8ZdAu3dXYx4AOowkmkkxri7dGHsnEP8Pv+SZiQxGhzShT9Djz6E3c5K0y5BApwPb7LscsCwduWkyp2CjYQXlJ78EylTr3/5skLvvwg6QNVzOyvbGleR5vSfc4yOb/FDhqp6gblUuVuxKzppKYBndU30oejjU4zPulzzOeD5lUTv1teL7m2Lf05aWrpvH5ol8GLpwYHOX/CPJuT6+ATr2N6m9SimLSCgLNgBAefLYXDsP4ojWhZ9/2ST+Ph4KnInT0q6TfUvvATPBgGl4NMZCqtYzzpDHRiJDYgkig5dveb97YzEEldcOCtkHb87Ui32DXo6dzYg5neSmI0Sp8hKQQmCmdZ2VCiJ+NdzF1IK9uFexr2A6ZY/nRabu1yf2htOJiQGvDqUzTtQaBdz6b7NxMw7ZIaARIrPJHur0Mv/FFY7vWKTX0hdbMlu6+BvHNgoB6pPQmqbJOS3aFI8XEmriJsV0QGxnborfc1ySVrQYVCUsC6cDjY/+MK6DkNqjkEYYEhzIUc20GFlr9nDtqe7kVW+kIXjaXcinlECoZ/M+TU/FQRC/YgfplLHtIVfAjiswqQLUg1U2iYhuAhpHWZClyCWWLGTRZJHw67ccMXwWfUOOAIjFSUauYakXvs15wJTCCdP0pMJjhd8VuBvdLlkyRlP2fQgOkgh4M9UE4lwTreWpx3SgVOBAsFt,iv:MFse+DAzp2pnmCirr1ufhjgGAtQyCPUXHevEnM8vDu4=,tag:WB2IBSUpvjRCxS8idl8suQ==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByZU5JUkZ3TnZRUktKZmRs
-        YWxYT2FoT0U5QkxmdkFYZUZFM1lSUEg3U1ZNCmh1WVFpWWpxWEttZERtNkdnUXNZ
-        MURJUjVlWUdsd29QME5FWk9qdVQ1bzQKLS0tIFdSOHg2K3lsZVBsOXZIUWVmb2JK
-        dUpjNzR4ZWJKcFd2WFp1aXhQSzFEN2cKf1lZVM5l5P17ILoJfG8omk0WsYXl35EE
-        W7zZ+JmPQvR+VjW14s4dmPFuEc/Io1j6EavTuZHgAit4jmePE3z2kw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHRE9PZVpxU1RuSncvbFdT
+        Y3Zsd0NEYU1kOXdqRk5zMHUvWmVoRWZCaEhFCjQ2ZVBGSGRIbXZrZmRkQU85KzFV
+        eW44bU9yWjNFek1hdGIzNExOVGNFTVkKLS0tIDNEaVRtZmVWY1VpbmEvbFZLS0Uv
+        ZnQ2MnRuQnlFVTNpWmx6MGpLMXpRRmcK5OPsi3bqaxqMkys93RamygBw9m6KbWwu
+        KasQhlh9OBh0WjtXrKmaAvm8VUTwg7EExRc72CnMRIxSE8Aiy4xLPQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T14:32:03Z"
-  mac: ENC[AES256_GCM,data:7rRBv9ceJT72zpBvHxiW1/2kH7sud1DKYnC2eiA72V+fdwkstYyiOCXqLCuKFp1d+kJCSSEhjpD0H8InnegoceTVlr2AW3BXMmFwRF7x5KWugSRScHz31eQ+CIf4MIn/H0fWRkWY5/HzyA2VkCib79QTRcr/iVuB/E2YA0hpQ3A=,iv:A07AJJ2ZPTgUrrz32P8ZcMnXCN+wqEjvKatsV0wJOdg=,tag:wrh3Zyn5NeNL9QcXls8stQ==,type:str]
+  lastmodified: "2026-08-14T14:50:45Z"
+  mac: ENC[AES256_GCM,data:kbKif4LUVq2W8eBW0F91RpS2NziWGQ+Dk0BnIjaCTjOoiXqVdt+Nks8n0Pmi3fj9ku+XMzgFI5xSOzldfYlq7ZjP5JPXQwSra54wNWJ52wJqPm3RjzYyqgPILELSDWQQSWrnfuc4E7YNPIYDrOVaEXdrthftf3qr2BCMIe678Nc=,iv:CCH9Z3xKxs3FtOxYWzngKTidWMYq3Ov5U5K7GTI7J08=,tag:F6ipKzhMvYGo+otyqaFNoQ==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
@@ -10,7 +10,7 @@ stringData:
   GATE_ED25519_SEED: ENC[AES256_GCM,data:LFquHW6HLI7A5zokMtZ5AOvOycPdzEP4fSSNaJC0VXf5zB58ZTLMzUQhXdQ=,iv:1XuFl0895KMb6hcvDNj9Qv4nIQTIVJDHaQcbHvLwNUw=,tag:S4VTlKfOQcOBM6Rt4hnqcQ==,type:str]
   ca.crt: ENC[AES256_GCM,data:TMqdABOa370MOv2oyoChC2SC21B9iRgO3SsgPifQqknC5vfN0hIaN8qoIgk428MrFOuSzvgufrcFIezuGpi7QG03wPYg026ZmrcN6WdfwXEJW4mLGq/tRXn0va9LzmA1fqlDEvj+nXGVuLwb46CSuzMlwG9zQkGimzINklkSj50Ll/v3NiQjXMaP1Kug0EX3ufBv5ZvJfcb8D5WklT0G0XXPe1/md8ZdAu3dXYx4AOowkmkkxri7dGHsnEP8Pv+SZiQxGhzShT9Djz6E3c5K0y5BApwPb7LscsCwduWkyp2CjYQXlJ78EylTr3/5skLvvwg6QNVzOyvbGleR5vSfc4yOb/FDhqp6gblUuVuxKzppKYBndU30oejjU4zPulzzOeD5lUTv1teL7m2Lf05aWrpvH5ol8GLpwYHOX/CPJuT6+ATr2N6m9SimLSCgLNgBAefLYXDsP4ojWhZ9/2ST+Ph4KnInT0q6TfUvvATPBgGl4NMZCqtYzzpDHRiJDYgkig5dveb97YzEEldcOCtkHb87Ui32DXo6dzYg5neSmI0Sp8hKQQmCmdZ2VCiJ+NdzF1IK9uFexr2A6ZY/nRabu1yf2htOJiQGvDqUzTtQaBdz6b7NxMw7ZIaARIrPJHur0Mv/FFY7vWKTX0hdbMlu6+BvHNgoB6pPQmqbJOS3aFI8XEmriJsV0QGxnborfc1ySVrQYVCUsC6cDjY/+MK6DkNqjkEYYEhzIUc20GFlr9nDtqe7kVW+kIXjaXcinlECoZ/M+TU/FQRC/YgfplLHtIVfAjiswqQLUg1U2iYhuAhpHWZClyCWWLGTRZJHw67ccMXwWfUOOAIjFSUauYakXvs15wJTCCdP0pMJjhd8VuBvdLlkyRlP2fQgOkgh4M9UE4lwTreWpx3SgVOBAsFt,iv:MFse+DAzp2pnmCirr1ufhjgGAtQyCPUXHevEnM8vDu4=,tag:WB2IBSUpvjRCxS8idl8suQ==,type:str]
   PGUSER: ENC[AES256_GCM,data:1Fopk7xrocO7o1SK4GU=,iv:izTi1/ymW78FfTF2hzeZ7+UNZHIGvjiPOkImXeTnkt8=,tag:e4+F37lsCAjSZLcNAX3Asg==,type:str]
-  PGPASSWORD: ENC[AES256_GCM,data:cQOcwQr7bmfDaMF+8b72E1PKFfy6l40YasNOg3Mf90F2FTX4cC9YrMnjDbTWwBQE1QJT7LL+k9ZDCXzeGKewSM2K,iv:csxuUn0+JqEzgzhZChdjvlLTYFOXHtuIZ84VqPkUzis=,tag:O43pJXAVyAZ+ljLi09hjzQ==,type:str]
+  PGPASSWORD: ENC[AES256_GCM,data:YA8x8H8BB9VH81t2arPdDTDaGQB5RlUoYqg1DB9jMO17ATao30zkEzNEMPlzphB8uXi0JbBO0dNHqUwLy9Dqlg==,iv:eVsQNtkJxUNi/OeC+3Rr9tFSmrfUUiffynSxdHuoWqQ=,tag:gJR9EiiJmm2bAG78Pqg80A==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -22,8 +22,8 @@ sops:
         ZnQ2MnRuQnlFVTNpWmx6MGpLMXpRRmcK5OPsi3bqaxqMkys93RamygBw9m6KbWwu
         KasQhlh9OBh0WjtXrKmaAvm8VUTwg7EExRc72CnMRIxSE8Aiy4xLPQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T16:14:24Z"
-  mac: ENC[AES256_GCM,data:q6UbPccV8FiR6F3rC2sKcg6BLV7IrIfk787U5+DFGJXjYzlmkJLb1qz6TM+KXW7F/k7M/91WwsfeLO75aZGu28q8BNJys/JofcTjqIyJicNUdE7taCb/ymLVipQTIQVCSmN+p5tMniqV1vpBshtJAU4qM9FeuU5MtIVUhP8G3VY=,iv:mYFpzz0UGVHRhytf55Z3HRVhFvl30hJ+4sNCCiZh3D4=,tag:KJXZEo9WQqQMw/w6t3TBaQ==,type:str]
+  lastmodified: "2026-08-14T16:30:19Z"
+  mac: ENC[AES256_GCM,data:Rb2SsqIUE3SKZ4tD6EpHfS20ZJfkpnA8Th8B86pEFPcfCrBL8GiddEg10RVmQ6ztbitPO3t6rOcXfLNaTHQHJ0E5SPxbr3C3F6nmwPQ3NcVN7JVbLuh++/uLZYnKyCBJOAKL131bh+IYlLYKlxETb0jthu917HfGHYsfGlG9qFI=,iv:3mwWohT5mWkRHUQATri2RHW9v/n8w5vICuKUn8QWIXo=,tag:L7UdqmvkZI99bUQEMp8nbQ==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
@@ -1,0 +1,30 @@
+# DEPLOYMENT BLOCKER: encrypted placeholders only. Replace all six values with
+# production material before this Kustomization reaches the live branch.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: davidapps-gate-config
+type: Opaque
+stringData:
+  DATABASE_URL: ENC[AES256_GCM,data:R0ufgROYs1pUrJVN7E75BGwz5qN+NBx7QtFF3RpFV0dErFfGfnP4L8U63tTn0JpQXJ76CSlRzztvTpAGCw2t45sS/RXWaQDzLrHAD2GGXPFgM/amKwru9e04f5lwk2nBSMQXOmXNbrNpd6k/HEuVvsWxuDIwDs6t8Im6Qxv+uDkpBPjlhWhRj3S5igTONF1gLWPvOBZ44xq3zJpRXxbEpfn4,iv:CfzRF8lEvSF/ckDjW13PpE0M1bvxLW2XMe+QckSlvdc=,tag:eslkX6AP0+DArfmFwXbgtw==,type:str]
+  HANDOFF_STATE_KEY: ENC[AES256_GCM,data:HzYFTLFjUbsY8+6xWz+G7SuG/7OUQP7ibtBaUoi9DWzLjdA+6TKCFO1yBN0=,iv:lumgOQYfZ2D26y9QhBAHHEEmOOGMTuk6V9haEbfDv6k=,tag:RYVvWSeg7r2LfpEbRnUgAw==,type:str]
+  REVOCATION_HMAC_KEY: ENC[AES256_GCM,data:8yqna1l7dh1oFEF7XJuIO1oq5W6WDLqK5JexqJzOK0Bdn558BExGSsU+04/UCA==,iv:u0wiGz3WRLVLaBVthNAuk0Z7hIzW/cbYM1+Hz9unXCk=,tag:vuTX7EcNC8hl4xI2BGDIow==,type:str]
+  SHARE_LINK_SIGNING_KEY: ENC[AES256_GCM,data:g0ivZ2bxF5fVb7uEI88cppLPn6FItXwrJ9VJ1nJbcK3nR/eGNaRoT1YB4KjAaRZjug==,iv:Kc8eyLkoryjI0QZpGQxleGttCxtDytgYfnTkLCCWKOc=,tag:1TKcVl8YM61reHZ+2JKsLg==,type:str]
+  GATE_ED25519_SEED: ENC[AES256_GCM,data:4in4bCEY6HfBko3kq7W9ndBIiSe4p90mIvWsOLAvYKtqrENQn1KunOw=,iv:qr+LH3VRJJxqN3LZo1jrI/b0R9kb+Vbp2TkFccYYbqI=,tag:Mqb6oDkA82bQfY9mlxqG4A==,type:str]
+  ca.crt: ENC[AES256_GCM,data:sc9q6N7jFfuZ1dlhSZrA6zvkLzXSOIATEqFi1g==,iv:HceBrD/MPe4SmPGOjUA0r/FspAVelLjWvxvO1MSmY18=,tag:LMbWgc5PLXI94DuasjgN/g==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByZU5JUkZ3TnZRUktKZmRs
+        YWxYT2FoT0U5QkxmdkFYZUZFM1lSUEg3U1ZNCmh1WVFpWWpxWEttZERtNkdnUXNZ
+        MURJUjVlWUdsd29QME5FWk9qdVQ1bzQKLS0tIFdSOHg2K3lsZVBsOXZIUWVmb2JK
+        dUpjNzR4ZWJKcFd2WFp1aXhQSzFEN2cKf1lZVM5l5P17ILoJfG8omk0WsYXl35EE
+        W7zZ+JmPQvR+VjW14s4dmPFuEc/Io1j6EavTuZHgAit4jmePE3z2kw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-14T14:32:03Z"
+  mac: ENC[AES256_GCM,data:7rRBv9ceJT72zpBvHxiW1/2kH7sud1DKYnC2eiA72V+fdwkstYyiOCXqLCuKFp1d+kJCSSEhjpD0H8InnegoceTVlr2AW3BXMmFwRF7x5KWugSRScHz31eQ+CIf4MIn/H0fWRkWY5/HzyA2VkCib79QTRcr/iVuB/E2YA0hpQ3A=,iv:A07AJJ2ZPTgUrrz32P8ZcMnXCN+wqEjvKatsV0wJOdg=,tag:wrh3Zyn5NeNL9QcXls8stQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/auth/davidapps-gate/ks.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app davidapps-gate
+  namespace: &namespace auth
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      app.kubernetes.io/part-of: davidapps-auth
+  path: ./kubernetes/apps/auth/davidapps-gate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth
+resources:
+  - ./davidapps-gate/ks.yaml
+components:
+  - ../../flux/components/namespace
+  - ../../flux/components/regcred
+  - ../../flux/components/sops

--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
             image:
               repository: ghcr.io/home-operations/postgres-init
               tag: 18.4
-            envFrom: &envFrom
+            envFrom:
               - secretRef:
                   name: paperless-secret
         containers:
@@ -71,11 +71,20 @@ spec:
               PAPERLESS_DBENGINE: postgresql
               # Auth
               PAPERLESS_ACCOUNT_ALLOW_SIGNUPS: "false"
-              PAPERLESS_AUTO_LOGIN_USERNAME: admin
+              PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
+              PAPERLESS_SOCIAL_AUTO_SIGNUP: "true"
+              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
+              PAPERLESS_SOCIAL_ACCOUNT_SYNC_GROUPS: "false"
+              PAPERLESS_DISABLE_REGULAR_LOGIN: "false"
+              PAPERLESS_REDIRECT_LOGIN_TO_SSO: "false"
               # User permissions
               USERMAP_UID: "1000"
               USERMAP_GID: "1000"
-            envFrom: *envFrom
+            envFrom:
+              - secretRef:
+                  name: paperless-secret
+              - secretRef:
+                  name: paperless-oidc-secret
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/default/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/default/paperless/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./claim.yaml
   - ./nfs-pvc.yaml
   - ./secret.sops.yaml
+  - ./oidc-secret.sops.yaml
   - ./helmrelease.yaml
 components:
   - ../../../../flux/components/volsync

--- a/kubernetes/apps/default/paperless/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/default/paperless/app/oidc-secret.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-oidc-secret
+  annotations:
+    davidapps.dev/credentials: pending-provisioning
+type: Opaque
+stringData:
+  PAPERLESS_SOCIALACCOUNT_PROVIDERS: ENC[AES256_GCM,data:7JPtoThIaPq2l7qRI/ia2Q3GxSkTAS9vijXVsAyFPtsrUUptOW6fuSq1FHcBxnmSk5XyUV2FnuovE6P8YBdmDtVx8YKz5ysAMPN1RrUCFgjm6YXVMRJh599++DwM9uC/lhmtaq9X9bxQ7P6Q4kGb5UrSPHLO3FqgFEZYBRJsNA7a1rmU7ftZNSpBGeSkpJvHA6QABc0Ukgrf5htYd52dBL8d/LWsIOzAaZsBuceAjLpWQ70lhERgi+Zik1jnTmB4ybOde8jaktkmZvG+8hAhc7bcIKTapsOov3pr3PDIjqlK1oSSjjIMChN/GYH1ZhuDURKYNe5ibPUr3pq6jMsqsCQEjdhp614WNVnaSegOzSzVT26y60wNEdF3ZBHR4Qt4Aic/HfRNWPIbKd6vG1qYuIYipL14YX3i164B2+m0xTChgc+6WYc+B7o1zixWSg0XJKcAFEfdhNbcvdmsJ/jqqKBkAp+VmsRHDQufzt6gHAeTJnEII2/bsLRCe6ebVM3D9D+KdZfSSe5HlkGeNRJoInnSxeHgAqy6nDHkPMJiml0zAH9k+A/L+4FiuqY=,iv:2UJRRNpYSh1wwyKDp8Rl1gw/lywUzJGWV62E6l6Pvls=,tag:GFTVYxssU6gcsVkBiuzjzA==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmcmtwSmExajhFd0tGa2Rl
+        YmpEU1h2d08xUGRuTHFzN0pKazVNdEhDbkFvCkswS0hDZ3B1T3ljYTB4ZExaaWRl
+        SStDOE1PSDZOYmx6TG1MUkJFMmdQMnMKLS0tIGtCeUtFMzNvUXoxdm4ydHdtQ2hZ
+        di93OVY4MzUwR21wZjBMREpCKzNmeFEK8QqLkkKrJbFqqj9K4RqryV8Bq+tTVaVG
+        cieKO6sy54xk3A7pQhWR7czxKgmZGHO+AMrrm0pxcn937PTJyUsDVw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-14T14:34:42Z"
+  mac: ENC[AES256_GCM,data:8/OzJBb5i1Jgp0MZZlA8FKBx8C1ZcP6aEUCSYkhHrCRkik6DRfTA9bYw0Y6b1bwBY54zC27vzShDXIwQFtEi8fteakH2gQW3Mtbc8SInUrf2L3ZBGUrUfqLr1EZ7AwMI71uxpUHOfmChjIuz+V3zcBxrYN8VEAVZaTywXeebTRg=,iv:nefW42rb2wHzemSgifCaoLYBJjjYIdiQu2MddePEz40=,tag:UZNUiBmGEEzLHZSzdSV4KA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/default/paperless/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/default/paperless/app/oidc-secret.sops.yaml
@@ -3,23 +3,23 @@ kind: Secret
 metadata:
   name: paperless-oidc-secret
   annotations:
-    davidapps.dev/credentials: pending-provisioning
+    davidapps.dev/credentials: provisioned
 type: Opaque
 stringData:
-  PAPERLESS_SOCIALACCOUNT_PROVIDERS: ENC[AES256_GCM,data:7JPtoThIaPq2l7qRI/ia2Q3GxSkTAS9vijXVsAyFPtsrUUptOW6fuSq1FHcBxnmSk5XyUV2FnuovE6P8YBdmDtVx8YKz5ysAMPN1RrUCFgjm6YXVMRJh599++DwM9uC/lhmtaq9X9bxQ7P6Q4kGb5UrSPHLO3FqgFEZYBRJsNA7a1rmU7ftZNSpBGeSkpJvHA6QABc0Ukgrf5htYd52dBL8d/LWsIOzAaZsBuceAjLpWQ70lhERgi+Zik1jnTmB4ybOde8jaktkmZvG+8hAhc7bcIKTapsOov3pr3PDIjqlK1oSSjjIMChN/GYH1ZhuDURKYNe5ibPUr3pq6jMsqsCQEjdhp614WNVnaSegOzSzVT26y60wNEdF3ZBHR4Qt4Aic/HfRNWPIbKd6vG1qYuIYipL14YX3i164B2+m0xTChgc+6WYc+B7o1zixWSg0XJKcAFEfdhNbcvdmsJ/jqqKBkAp+VmsRHDQufzt6gHAeTJnEII2/bsLRCe6ebVM3D9D+KdZfSSe5HlkGeNRJoInnSxeHgAqy6nDHkPMJiml0zAH9k+A/L+4FiuqY=,iv:2UJRRNpYSh1wwyKDp8Rl1gw/lywUzJGWV62E6l6Pvls=,tag:GFTVYxssU6gcsVkBiuzjzA==,type:str]
+  PAPERLESS_SOCIALACCOUNT_PROVIDERS: ENC[AES256_GCM,data:2iILTr2MCnJcHPXy89HRvAGyyTWO9om0PZVTSfepwvc2SnFbkBSfeTaGTgfpg8+UI0/VtjRXyrXR4JJ3a00mkZcQwITG/YF0WnZPGYSKsAyLD54/KgsM9oQnEYNZc9YfRzIKMbsx7qMxGAqqaqU4tyuiJ5eNhIVAcs0t+5p/0H6/iynkOqrMQvY2yefIU2CnkWzUstXEr0OADioFUXewcNu3L6Py0f+vqRM0daoVCG056tcU5i+c+6CnP/vJypL4DG0FyfKMpqWmTcEzHeEMgEj2lz7lw7bYUcvwdoJGC0x/Lf86TlF4CGm5f3Zq2Pm6zGIY61HUcurGoP1YiHiHK94V5IdAoOU3wBhs1wbpTWNQaM3AEqJ6Ufs8L80kVRN/VIsrJzfbSeteGoNncVxSN9cAI44Pq27aqltHW3UnCRoSvA6q7/IilhRuPYzAcIy+dsJozPngyVsu05dwmGA+3v/GOcWzg6WwDJEtt8w44ELW4v1L1pbft8Me9y9e14QWHeXx3gAus6TeYMqjqKhsfSXVBKo5XF6gHw==,iv:fXK8/jYgEx2XFoKh2/H3vhRS6C3GToY0Ds5TAiR6Cag=,tag:W9ckFlReeyuqLQt+WZ41Jg==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmcmtwSmExajhFd0tGa2Rl
-        YmpEU1h2d08xUGRuTHFzN0pKazVNdEhDbkFvCkswS0hDZ3B1T3ljYTB4ZExaaWRl
-        SStDOE1PSDZOYmx6TG1MUkJFMmdQMnMKLS0tIGtCeUtFMzNvUXoxdm4ydHdtQ2hZ
-        di93OVY4MzUwR21wZjBMREpCKzNmeFEK8QqLkkKrJbFqqj9K4RqryV8Bq+tTVaVG
-        cieKO6sy54xk3A7pQhWR7czxKgmZGHO+AMrrm0pxcn937PTJyUsDVw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5Ylp4MW03MnJMM1k5YmFP
+        OHAycGQ0ZU1EZkh1alBnNFN5bWhlK3ZFbXhJClBlM3l0c2tKUGcyT3lrU1hpYjJB
+        NXVYZXo4a2dHclBMVVdWZlNjbXdNYzQKLS0tIGFjYlA3THZGbzd4U2dtajBmQVN0
+        TTUzMFFManBKYW95QzZiMVp1N0p6Q0EK6zOdVyLy9iw/+EK5fByAsCVtD58F8r7X
+        EORWlq8+9qdcoyDUmhOXp6jvUEkkXrZHINbQdns1dq/sPdmgJs4kyw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T14:34:42Z"
-  mac: ENC[AES256_GCM,data:8/OzJBb5i1Jgp0MZZlA8FKBx8C1ZcP6aEUCSYkhHrCRkik6DRfTA9bYw0Y6b1bwBY54zC27vzShDXIwQFtEi8fteakH2gQW3Mtbc8SInUrf2L3ZBGUrUfqLr1EZ7AwMI71uxpUHOfmChjIuz+V3zcBxrYN8VEAVZaTywXeebTRg=,iv:nefW42rb2wHzemSgifCaoLYBJjjYIdiQu2MddePEz40=,tag:UZNUiBmGEEzLHZSzdSV4KA==,type:str]
+  lastmodified: "2026-08-14T14:53:39Z"
+  mac: ENC[AES256_GCM,data:JTJdBcbGO8oUoQqjutXP9kg9j8pqQkCbURMyB6y7QzPcWBAquGbiOMKKiiyShgofiSuAVNC6XfGcm/5yzoL9uWZ4cnbJB8QQosuxey4+BXs/uC4iWBDNfe17B0pnesQJQwrLxRnuU35W/+34AYkpCcTjG7LPcqCReobTqfEo5dg=,iv:Cuiec29Usp4fB8rzFSCdFqIhJU5wFfzUqt/hzQZ9KSk=,tag:abNkWqnVbaE7pRwjgC7log==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -38,9 +38,15 @@ spec:
             env:
               TZ: Europe/Bucharest
               QUI__PORT: &port 80
+              QUI__OIDC_ENABLED: "true"
+              QUI__OIDC_ISSUER: https://id.davidapps.dev
+              QUI__OIDC_REDIRECT_URL: https://qui.davidhome.ro/api/auth/oidc/callback
+              QUI__OIDC_DISABLE_BUILT_IN_LOGIN: "false"
             envFrom:
               - secretRef:
                   name: qui-secret
+              - secretRef:
+                  name: qui-oidc-secret
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/downloads/qui/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/qui/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./secret.sops.yaml
+  - ./oidc-secret.sops.yaml
   - ./claim.yaml
   - ./helmrelease.yaml
 components:

--- a/kubernetes/apps/downloads/qui/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/downloads/qui/app/oidc-secret.sops.yaml
@@ -3,24 +3,24 @@ kind: Secret
 metadata:
   name: qui-oidc-secret
   annotations:
-    davidapps.dev/credentials: pending-provisioning
+    davidapps.dev/credentials: provisioned
 type: Opaque
 stringData:
-  QUI__OIDC_CLIENT_ID: ENC[AES256_GCM,data:Q6MDvy0W6u0ktB/wg1+hULNMtlNCnJQalyYm6/LbDufBVu3lOTNoMqhVX3aD,iv:A7uS40CCv0QeMxFLibVoBYcl+UGwxQ22b424M0gOtNY=,tag:cY5PBKhGo9EUYzRLLMdhdg==,type:str]
-  QUI__OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:QVfsRc5Ieb+hiqev+oVyxSsGFY0vFBlyEAl/+c7o4BwCmsPe8AWIsTIJG/WU4mzrWg==,iv:9ZMsarbGOeAADBy/bf/JkoqJO7Us4IgDYkX3I5MBCAo=,tag:qGvROaAogYWifvKPmZZ52A==,type:str]
+  QUI__OIDC_CLIENT_ID: ENC[AES256_GCM,data:megb61floPitb9/51s/y0No8pWCzy+U3mzXJkC98MAo=,iv:FWY2L9JdZhC7ruWdCcmy2Xe15FR1VJjvgwA+oNpI1S8=,tag:V2tlb0VAOt6K+PVtE4FxcA==,type:str]
+  QUI__OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:63/ZNLjdv+0DFUorsaeactho0u3yedlzSr08LEMDfJXgPejWCY5LTGkrig==,iv:VKBpygyxaPiEepY7IPz6qRJ1Xj9pBRUMs/IVnN9Zmd0=,tag:tnB6fkleg4f/ShScsEAtkw==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQbFdjTVRlUDdEVytwVWVX
-        UDFwbVg2U0dUazdHT0J5M1B1ZkdqWTN5andFCkNUR0I2ZzBiRjJkcUF2d09LSHJl
-        dm9hQlR4VGlkd0tDVldZZnM5Q2U5RXMKLS0tIHZNbkE3bnljQVo0QVNESkpKa0p1
-        VCtpZDVPK0I0SWtKc1drNlBuRDFwNmMKiuI/4tdkF17tFUKhZvk6LJxgjfoWLcxm
-        aoc/atVGHJUqH8jEsN+QWC33o3aqO1bG6N3KJcPptkZ2cPqSSGv0zw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBRGw4ZjQwWmtGc3lkUXlr
+        ZWMrelZqM0dwQll5dmNOakRqUFhCUlFsY2xjClhxYkhIT0FkdXBEUGw1U3Vrdkcy
+        Skt3cmoxNGVuT1dhbGV4S0IzUW1IaTgKLS0tIFZMWWFVWGd5Y0huS1VVbHd1dDdv
+        K2RCbjhsNW5uUXNwMzU3c2RYakloUFUKwvos8/rPCFO6DHbD7WuLj8ZpKT/cseR3
+        kQJUWcxDnXNY6+6u+UdFVPJLON47lRhF/L+oqG4lv1cwA5Yc8Kqy+A==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T14:34:42Z"
-  mac: ENC[AES256_GCM,data:67a5a4TyWRmpKWuWXCB84t+FcQJnmM61WVT1VoFJ+eLCCUBj0afLKgpjzwaXpSJgTtDg2+jwjv066DAZNxbSW/NnawPoryJ4Wqe3oVCxnrVS45lJHCbqh5VkMaX9cS3m8b1LWW1sV54tlaZpWl7vNe9NYQbG9c/eKgkxBBRavkc=,iv:ufe1DDBg6pcKMHPSBT21esuZLPzpoEsOd8nmrutBTMI=,tag:9swkoWRHTeRyo6dlgqQLpA==,type:str]
+  lastmodified: "2026-08-14T14:53:43Z"
+  mac: ENC[AES256_GCM,data:dF75nq2MXEteKKhghPliOAnUfjdGXetsH1RSntBPfA8hTAQM3jm3H//CD5rZgGjRiM23Py6DwtHX5t5UvnMGFvGV/LM9oytspd470Eai2APa/H+nSBNGv59RGr71GkH8+JkDYTb3lKKM2/IL20PdbBlnuqE7vhQtMyN6hzB18dM=,iv:Vy7gRgLvKnfLzGI7DrPoXH+BkFQNIcD4XWAI54cNMQs=,tag:UqNl97pQ5YKrBmbDJknvdw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/downloads/qui/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/downloads/qui/app/oidc-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: qui-oidc-secret
+  annotations:
+    davidapps.dev/credentials: pending-provisioning
+type: Opaque
+stringData:
+  QUI__OIDC_CLIENT_ID: ENC[AES256_GCM,data:Q6MDvy0W6u0ktB/wg1+hULNMtlNCnJQalyYm6/LbDufBVu3lOTNoMqhVX3aD,iv:A7uS40CCv0QeMxFLibVoBYcl+UGwxQ22b424M0gOtNY=,tag:cY5PBKhGo9EUYzRLLMdhdg==,type:str]
+  QUI__OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:QVfsRc5Ieb+hiqev+oVyxSsGFY0vFBlyEAl/+c7o4BwCmsPe8AWIsTIJG/WU4mzrWg==,iv:9ZMsarbGOeAADBy/bf/JkoqJO7Us4IgDYkX3I5MBCAo=,tag:qGvROaAogYWifvKPmZZ52A==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQbFdjTVRlUDdEVytwVWVX
+        UDFwbVg2U0dUazdHT0J5M1B1ZkdqWTN5andFCkNUR0I2ZzBiRjJkcUF2d09LSHJl
+        dm9hQlR4VGlkd0tDVldZZnM5Q2U5RXMKLS0tIHZNbkE3bnljQVo0QVNESkpKa0p1
+        VCtpZDVPK0I0SWtKc1drNlBuRDFwNmMKiuI/4tdkF17tFUKhZvk6LJxgjfoWLcxm
+        aoc/atVGHJUqH8jEsN+QWC33o3aqO1bG6N3KJcPptkZ2cPqSSGv0zw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-14T14:34:42Z"
+  mac: ENC[AES256_GCM,data:67a5a4TyWRmpKWuWXCB84t+FcQJnmM61WVT1VoFJ+eLCCUBj0afLKgpjzwaXpSJgTtDg2+jwjv066DAZNxbSW/NnawPoryJ4Wqe3oVCxnrVS45lJHCbqh5VkMaX9cS3m8b1LWW1sV54tlaZpWl7vNe9NYQbG9c/eKgkxBBRavkc=,iv:ufe1DDBg6pcKMHPSBT21esuZLPzpoEsOd8nmrutBTMI=,tag:9swkoWRHTeRyo6dlgqQLpA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/infastructure/portainer/app/helmrelease.yaml
+++ b/kubernetes/apps/infastructure/portainer/app/helmrelease.yaml
@@ -17,6 +17,8 @@ spec:
         name: portainer
         namespace: flux-system
   values:
+    service:
+      type: ClusterIP
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -37,11 +37,42 @@ spec:
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel
       GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
       GF_SERVER_ROOT_URL: "https://monitoring.davidapps.dev"
+    envValueFrom:
+      GF_AUTH_GENERIC_OAUTH_CLIENT_ID:
+        secretKeyRef:
+          name: grafana-oidc-secret
+          key: client-id
+      GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+        secretKeyRef:
+          name: grafana-oidc-secret
+          key: client-secret
     grafana.ini:
       analytics:
         check_for_updates: false
         check_for_plugin_updates: false
         reporting_enabled: false
+      auth:
+        disable_login_form: false
+      auth.basic:
+        enabled: true
+      auth.generic_oauth:
+        name: DavidApps
+        enabled: true
+        allow_sign_up: true
+        auto_login: false
+        auth_url: https://id.davidapps.dev/api/auth/oauth2/authorize
+        token_url: https://id.davidapps.dev/api/auth/oauth2/token
+        api_url: https://id.davidapps.dev/api/auth/oauth2/userinfo
+        scopes: "openid profile email offline_access"
+        auth_style: InHeader
+        use_pkce: true
+        use_refresh_token: true
+        validate_id_token: true
+        jwk_set_url: https://id.davidapps.dev/api/auth/jwks
+        login_attribute_path: sub
+        name_attribute_path: name
+        email_attribute_path: email
+        skip_org_role_sync: true
       news:
         news_feed_enabled: false
     datasources:

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./secret.sops.yaml
+  - ./oidc-secret.sops.yaml

--- a/kubernetes/apps/observability/grafana/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/observability/grafana/app/oidc-secret.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-oidc-secret
+  annotations:
+    davidapps.dev/credentials: pending-provisioning
+type: Opaque
+stringData:
+  client-id: ENC[AES256_GCM,data:O2ar5rE236tZiOM4v1BXsGlQGL3SXdRbx3nd9x3Toxgn6TKgmy/0j5HIw+G1,iv:1x/ZZaFAgugJMdUnL0SXp82mhMPOrQA+uwYiJy/9ec4=,tag:P4wbGK5VZAxbPPU8bbJZzw==,type:str]
+  client-secret: ENC[AES256_GCM,data:gQfh8TlJrtJSjxw5V0YbHYt3bvK/A5q7uyTxbUL/XSWQOg7TA6QizCczpfgc54P5Dw==,iv:CMTzz+TlZSteiZNGQPc0j2Zns5oQzPSCEc3rugDofJU=,tag:uhz4cElBm7Cxzc5zParifg==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFenNYcFFUUHhiUW5WR3Fq
+        NjVydDhYRzF1ckV6eWZxUUdJVm1Yd1dRTW1ZClZhTlFKYmh0L3VYcEF4NXdTQ0Z2
+        MzJTd1ZQMzI5RVUwbXA2ajVTRXkvSXcKLS0tIDFVdEl6cU40SjBPRlJIWFdLb0tQ
+        NlFJZGdUQ3ZGQk1Nb2xFYldoZ3JUcm8Kue2OMeHddjpGYuHGjDzHjqZgB20/2lub
+        pQ7yqLoW3DajkP33QOXKcCXdMUQmVLN+CnHfLwJKnvj+p7dc3H0fVA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-14T14:34:42Z"
+  mac: ENC[AES256_GCM,data:g/KiLUbLVKzH4QZt49jUwH8oMstJT3Cgqf11U9/GwiPKsOFaeQbxiH9dHeMRSA9rb1fdl73XeUvxXM1npin1trhlFUmpIezlPsAkL9z4rpb6ufTygTkDwrswOYZZinKH/LX8v1iZ6MDwlKmGVBvDfOCnhoNCckDkVJbMGhsPhjY=,iv:ZFw1afA8K/NN7VMyanti2YTeG1XQ8dtP17j1KBNZ18Y=,tag:sJKvIuN2Vo8vKWofexquzQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/observability/grafana/app/oidc-secret.sops.yaml
+++ b/kubernetes/apps/observability/grafana/app/oidc-secret.sops.yaml
@@ -3,24 +3,24 @@ kind: Secret
 metadata:
   name: grafana-oidc-secret
   annotations:
-    davidapps.dev/credentials: pending-provisioning
+    davidapps.dev/credentials: provisioned
 type: Opaque
 stringData:
-  client-id: ENC[AES256_GCM,data:O2ar5rE236tZiOM4v1BXsGlQGL3SXdRbx3nd9x3Toxgn6TKgmy/0j5HIw+G1,iv:1x/ZZaFAgugJMdUnL0SXp82mhMPOrQA+uwYiJy/9ec4=,tag:P4wbGK5VZAxbPPU8bbJZzw==,type:str]
-  client-secret: ENC[AES256_GCM,data:gQfh8TlJrtJSjxw5V0YbHYt3bvK/A5q7uyTxbUL/XSWQOg7TA6QizCczpfgc54P5Dw==,iv:CMTzz+TlZSteiZNGQPc0j2Zns5oQzPSCEc3rugDofJU=,tag:uhz4cElBm7Cxzc5zParifg==,type:str]
+  client-id: ENC[AES256_GCM,data:dAk9o0SXb3XoEX8ff9GnnR1U8eXeJce//cI94Gnfxwo=,iv:5n74QVW1LMf0gRMgYjaGMsXlN5GIIeTSL1eX0U1mGi8=,tag:O2spP3JFqyCCULFajFYXNw==,type:str]
+  client-secret: ENC[AES256_GCM,data:jwQKT8fQnb0bEMfTpWH9AZf0k9FRdz+aLzjGQyfEBihjkrnAOxYZiDrd3A==,iv:cA7MbOMD5SWYhNDVnNJt6nGgMtPYZqeE/UFQcgrp1ps=,tag:5KKZiSgWzmwrScpJsauhoQ==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFenNYcFFUUHhiUW5WR3Fq
-        NjVydDhYRzF1ckV6eWZxUUdJVm1Yd1dRTW1ZClZhTlFKYmh0L3VYcEF4NXdTQ0Z2
-        MzJTd1ZQMzI5RVUwbXA2ajVTRXkvSXcKLS0tIDFVdEl6cU40SjBPRlJIWFdLb0tQ
-        NlFJZGdUQ3ZGQk1Nb2xFYldoZ3JUcm8Kue2OMeHddjpGYuHGjDzHjqZgB20/2lub
-        pQ7yqLoW3DajkP33QOXKcCXdMUQmVLN+CnHfLwJKnvj+p7dc3H0fVA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWV1NOS2Y1Qm15VHVTbDJj
+        YU9rck1sRzJRUm9jSmNEbDdjN1YzQ2ZQLzE4ClBwRjVNZXVpRHBkeVdMN1B1Qzl5
+        aVZYR0lWYlFFS1YwWGppZGZIVFF1R1kKLS0tIGtrV2c0S3dBMUEybXV0NG9zSGNk
+        Qk1Oa3BGYmFWcGxFemp0TS85V3I5b2sKqA10t62nDwcuL/otzO9B0dPA0jQU0axm
+        5QD5aywlsuoXrNmprr9sdQBUIjtTZv/nDwMbDReNNHWQSAWV4wg/DQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T14:34:42Z"
-  mac: ENC[AES256_GCM,data:g/KiLUbLVKzH4QZt49jUwH8oMstJT3Cgqf11U9/GwiPKsOFaeQbxiH9dHeMRSA9rb1fdl73XeUvxXM1npin1trhlFUmpIezlPsAkL9z4rpb6ufTygTkDwrswOYZZinKH/LX8v1iZ6MDwlKmGVBvDfOCnhoNCckDkVJbMGhsPhjY=,iv:ZFw1afA8K/NN7VMyanti2YTeG1XQ8dtP17j1KBNZ18Y=,tag:sJKvIuN2Vo8vKWofexquzQ==,type:str]
+  lastmodified: "2026-08-14T14:53:37Z"
+  mac: ENC[AES256_GCM,data:pGDrJEcVA9BTrdkQg6d6sYj3basX6ElW38yLn1foVSbWIPmIzsUyz7pQBtGRm8RFPUyO6Ib5/y7u6JIGiykPJw7xFKqu7oteWEvOwuq5/vA0NzJXnc0JZf40Lz6N49Ed3uiVpopyrxY+rN1ebOtOJxRBCVMYKLgMhUF7DmgtGvw=,iv:nbu2jvI9Bayo/5/k0Tg44t7KkIMuZQN52aT0JaypBrA=,tag:108a/KYXOT0aRkPt3TWVDw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1


### PR DESCRIPTION
## Summary

- deploy the home-cluster DavidApps checker and replay store in the `auth` namespace
- connect the checker to the central identity database over the encrypted, allowlisted database endpoint
- prepare native OIDC settings for Grafana, Paperless-ngx, Open WebUI, and qui
- stage Home Assistant, Portainer, and Proxmox appliance setup with recovery-safe runbooks
- keep ingress authentication boundaries in the separate follow-up branch

## Safety

- all credentials and signing material remain SOPS-encrypted
- Portainer internal authentication stays visible; its OAuth Logout URL must remain blank on 2.39.6
- Proxmox realm creation remains blocked until DavidApps ships `preferred_username`
- no application boundary is activated by this PR

## Validation

- `flux-local v8.4.0`: 206 passed
- every changed `*.sops.yaml` reports encrypted
- `git diff --check` clean

## Rollout dependency

Do not merge until the central DavidApps main-12 rollout and cross-cluster database endpoint are live and healthy.