### PR TITLE
fix(auth): encode regional gate seed as hex

### DIFF
--- a/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/gate.yaml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        davidapps.dev/config-revision: gate-seed-hex-v1
         reloader.stakater.com/auto: "true"
       labels:
         app.kubernetes.io/name: davidapps-gate

--- a/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/secret.sops.yaml
@@ -7,7 +7,7 @@ stringData:
   HANDOFF_STATE_KEY: ENC[AES256_GCM,data:74gmaNmcCpc1Yzez9ZfKh42fujEO+MkFZVSqk6yZv+Td3PCN3BVm/L1dZWYuiWKKZjgABaC8BNpQatpIiWq/8Q==,iv:iGQNowJfzh8MnVvJhlUrcuLS4eiSTRAoFiIuqEymGZs=,tag:+9dlahaCcyXd04xtCvlQAg==,type:str]
   REVOCATION_HMAC_KEY: ENC[AES256_GCM,data:oyepzKxsOvUeaCOOohZcdTG7ogCdNfRRkpPR1dnHys96Xz+N4Egzs7kSETA8gM1hgJyVmNHzGivH6HXHivtFmQ==,iv:v4IXYAFdPfyMh4z0gucMB2IcyYbJAFHT541LtfsV1UE=,tag:5myCQpgQRqGyK1EfyiOjXg==,type:str]
   SHARE_LINK_SIGNING_KEY: ENC[AES256_GCM,data:YzOFPtTONyJnGBjGoyVBTghPDq5JuKkNo5OWp/VomfZztb3zLue3Rhxbki/3VjxYTSasw+0heGOc0V8nyXOmVQ==,iv:qJUW/qikWik6Q1fKYxhtTdGOXma0sHimoLYG28VLyxA=,tag:r0WlkRjHVRaxzmMTc2zXgQ==,type:str]
-  GATE_ED25519_SEED: ENC[AES256_GCM,data:LFquHW6HLI7A5zokMtZ5AOvOycPdzEP4fSSNaJC0VXf5zB58ZTLMzUQhXdQ=,iv:1XuFl0895KMb6hcvDNj9Qv4nIQTIVJDHaQcbHvLwNUw=,tag:S4VTlKfOQcOBM6Rt4hnqcQ==,type:str]
+  GATE_ED25519_SEED: ENC[AES256_GCM,data:8VuRove9FQOYUtZsrMNnOfzvAZuH/GZ3JYiEOMT6MtuY2XBKzbeSi2imp/1vh+xuNeqOCDHgk+xnRoE5c+Jj/w==,iv:QqjhS6xpcv6Ypvl/TaJwnNuPehqna6f2DiqxkSISMcU=,tag:r7kkq0wp4p8fiBkNdrDUdQ==,type:str]
   ca.crt: ENC[AES256_GCM,data:TMqdABOa370MOv2oyoChC2SC21B9iRgO3SsgPifQqknC5vfN0hIaN8qoIgk428MrFOuSzvgufrcFIezuGpi7QG03wPYg026ZmrcN6WdfwXEJW4mLGq/tRXn0va9LzmA1fqlDEvj+nXGVuLwb46CSuzMlwG9zQkGimzINklkSj50Ll/v3NiQjXMaP1Kug0EX3ufBv5ZvJfcb8D5WklT0G0XXPe1/md8ZdAu3dXYx4AOowkmkkxri7dGHsnEP8Pv+SZiQxGhzShT9Djz6E3c5K0y5BApwPb7LscsCwduWkyp2CjYQXlJ78EylTr3/5skLvvwg6QNVzOyvbGleR5vSfc4yOb/FDhqp6gblUuVuxKzppKYBndU30oejjU4zPulzzOeD5lUTv1teL7m2Lf05aWrpvH5ol8GLpwYHOX/CPJuT6+ATr2N6m9SimLSCgLNgBAefLYXDsP4ojWhZ9/2ST+Ph4KnInT0q6TfUvvATPBgGl4NMZCqtYzzpDHRiJDYgkig5dveb97YzEEldcOCtkHb87Ui32DXo6dzYg5neSmI0Sp8hKQQmCmdZ2VCiJ+NdzF1IK9uFexr2A6ZY/nRabu1yf2htOJiQGvDqUzTtQaBdz6b7NxMw7ZIaARIrPJHur0Mv/FFY7vWKTX0hdbMlu6+BvHNgoB6pPQmqbJOS3aFI8XEmriJsV0QGxnborfc1ySVrQYVCUsC6cDjY/+MK6DkNqjkEYYEhzIUc20GFlr9nDtqe7kVW+kIXjaXcinlECoZ/M+TU/FQRC/YgfplLHtIVfAjiswqQLUg1U2iYhuAhpHWZClyCWWLGTRZJHw67ccMXwWfUOOAIjFSUauYakXvs15wJTCCdP0pMJjhd8VuBvdLlkyRlP2fQgOkgh4M9UE4lwTreWpx3SgVOBAsFt,iv:MFse+DAzp2pnmCirr1ufhjgGAtQyCPUXHevEnM8vDu4=,tag:WB2IBSUpvjRCxS8idl8suQ==,type:str]
   PGUSER: ENC[AES256_GCM,data:1Fopk7xrocO7o1SK4GU=,iv:izTi1/ymW78FfTF2hzeZ7+UNZHIGvjiPOkImXeTnkt8=,tag:e4+F37lsCAjSZLcNAX3Asg==,type:str]
   PGPASSWORD: ENC[AES256_GCM,data:YA8x8H8BB9VH81t2arPdDTDaGQB5RlUoYqg1DB9jMO17ATao30zkEzNEMPlzphB8uXi0JbBO0dNHqUwLy9Dqlg==,iv:eVsQNtkJxUNi/OeC+3Rr9tFSmrfUUiffynSxdHuoWqQ=,tag:gJR9EiiJmm2bAG78Pqg80A==,type:str]
@@ -22,8 +22,8 @@ sops:
         ZnQ2MnRuQnlFVTNpWmx6MGpLMXpRRmcK5OPsi3bqaxqMkys93RamygBw9m6KbWwu
         KasQhlh9OBh0WjtXrKmaAvm8VUTwg7EExRc72CnMRIxSE8Aiy4xLPQ==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-14T16:30:19Z"
-  mac: ENC[AES256_GCM,data:Rb2SsqIUE3SKZ4tD6EpHfS20ZJfkpnA8Th8B86pEFPcfCrBL8GiddEg10RVmQ6ztbitPO3t6rOcXfLNaTHQHJ0E5SPxbr3C3F6nmwPQ3NcVN7JVbLuh++/uLZYnKyCBJOAKL131bh+IYlLYKlxETb0jthu917HfGHYsfGlG9qFI=,iv:3mwWohT5mWkRHUQATri2RHW9v/n8w5vICuKUn8QWIXo=,tag:L7UdqmvkZI99bUQEMp8nbQ==,type:str]
+  lastmodified: "2026-08-14T16:42:20Z"
+  mac: ENC[AES256_GCM,data:w1Hm6IMXNAmSCHP300eF8Omgi1tOA/fbrQQEyya2bANOKckOkcM5w3XRyakiyBkNhjHDaSRElUDAr9r15e6kIDb6mdoELoT9LyrZFZp6jTgqggCJ3sM7CFmn8fuY9Xyqy+Ue91980BUSg0EB9HGpSDZM6RTr/c/RXuIqWAjS9P4=,iv:VyJRf/i7EUJBDPMBAtUPTMD9D1jxhLX+rpBqsyCxI7k=,tag:+v9+Uh95RPjF3sOD5oRxLw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1


### PR DESCRIPTION
The regional gate fails closed at startup because `GATE_ED25519_SEED` was staged as base64 while the runtime contract requires a 64-character hex seed.

This converts the existing 32 seed bytes from base64 to hex without rotating the key, so the derived public key remains unchanged. All SOPS material remains encrypted.

Verified secret-safely: all four signing/HMAC values are valid 64-character hex, the database credential matches the normalized managed role secret, and the database CA parses as X.509.