### PR TITLE
feat(auth): expose private revocation receiver

### DIFF
--- a/kubernetes/apps/auth/davidapps-gate/app/kustomization.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./secret.sops.yaml
   - ./dragonfly.yaml
   - ./gate.yaml
+  - ./revocation-ingress.yaml
   - ./networkpolicy.yaml

--- a/kubernetes/apps/auth/davidapps-gate/app/revocation-ingress.yaml
+++ b/kubernetes/apps/auth/davidapps-gate/app/revocation-ingress.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: davidapps-gate-revocation
+  annotations:
+    gatus.home-operations.com/enabled: "false"
+spec:
+  ingressClassName: internal
+  rules:
+    - host: &host gate-home.davidhome.ro
+      http:
+        paths:
+          - path: /internal/revoke
+            pathType: Exact
+            backend:
+              service:
+                name: davidapps-gate
+                port:
+                  number: 8080
+  tls:
+    - hosts: [*host]


### PR DESCRIPTION
Adds a private, exact-path-only TLS ingress for the regional DavidApps gate revocation receiver at `https://gate-home.davidhome.ro/internal/revoke`.

- Uses the existing internal ingress controller and wildcard certificate
- Publishes DNS through the existing internal external-dns/UniFi path
- Routes only the exact `/internal/revoke` path to port 8080
- Leaves checks, metrics, and user-facing gate endpoints unexposed
- Request and response bodies remain authenticated by the existing HMAC protocol