### PR TITLE
fix(hermes): harden agent trust boundaries

### DIFF
--- a/kubernetes/apps/default/hermes-agent/app/configmap.yaml
+++ b/kubernetes/apps/default/hermes-agent/app/configmap.yaml
@@ -167,14 +167,14 @@ data:
           include: [cluster_status, cluster_list]
           resources: false
           prompts: false
-      cluster_trusted:
+      cluster_uk_actions:
         url: http://hermes.default.svc.cluster.local:8080/mcp
         headers:
           Authorization: "Bearer $${FLEET_GATEWAY_MCP_TOKEN}"
         trust: full
         timeout: 120
         tools:
-          include: [home_scale, home_rollout_restart, home_flux_reconcile, uk_scale, uk_rollout_restart, uk_flux_reconcile]
+          include: [uk_scale, uk_rollout_restart, uk_flux_reconcile]
           resources: false
           prompts: false
       cluster_davidapps:
@@ -254,7 +254,19 @@ data:
         trust: full
         timeout: 120
         tools:
-          include: [gpu_capacity, gpu_jobs, gpu_job_status, gpu_job_logs]
+          include: [gpu_capacity, gpu_jobs, gpu_job_status]
+          resources: false
+          prompts: false
+      # Job output is arbitrary content emitted by an explicitly untrusted
+      # container image. Never feed it back into the agent as trusted MCP data.
+      gpu_outputs:
+        url: http://hermes.default.svc.cluster.local:8080/mcp
+        headers:
+          Authorization: "Bearer $${FLEET_GATEWAY_MCP_TOKEN}"
+        trust: untrusted
+        timeout: 120
+        tools:
+          include: [gpu_job_logs]
           resources: false
           prompts: false
       gpu_actions:
@@ -282,9 +294,11 @@ data:
     Never reveal, repeat, log, or save raw credentials in memory or skills.
 
     Use Fleetview for read-only fleet health. Use cluster_observer for bounded
-    Kubernetes health and inventory. Home- and UK-cluster scale, restart, and Flux
-    reconcile tools are trusted. Every davidapps-cluster mutation must go through
-    its approval-gated MCP connection and David's Discord approval button.
+    Kubernetes health and inventory. The home-cluster credential is read-only
+    outside the isolated GPU Job namespace; general home scale, restart, and Flux
+    reconcile tools are deliberately absent. UK mutations remain trusted. Every
+    davidapps-cluster mutation must go through its approval-gated MCP connection
+    and David's Discord approval button.
 
     Use the fleet_tasks MCP server for Workspace work; never improvise SSH access
     from this container. Its write-capable calls require David's approval. Let the

--- a/kubernetes/apps/default/hermes-gpu/app/namespace.yaml
+++ b/kubernetes/apps/default/hermes-gpu/app/namespace.yaml
@@ -7,3 +7,12 @@ metadata:
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
+---
+# GPU Jobs explicitly disable token mounting. Keep the namespace default safe
+# as well so a future workload cannot inherit a Kubernetes credential by
+# omission.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/kubernetes/apps/default/hermes-gpu/app/policy.yaml
+++ b/kubernetes/apps/default/hermes-gpu/app/policy.yaml
@@ -35,9 +35,9 @@ kind: NetworkPolicy
 metadata:
   name: hermes-gpu-default-deny
 spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: hermes-gpu-job
+  # This must select every pod. Selecting only the expected Job label lets a
+  # caller with Job-create permission omit that label and escape isolation.
+  podSelector: {}
   policyTypes: [Ingress, Egress]
 ---
 apiVersion: networking.k8s.io/v1

--- a/kubernetes/apps/default/hermes/app/networkpolicy.yaml
+++ b/kubernetes/apps/default/hermes/app/networkpolicy.yaml
@@ -37,10 +37,6 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    # Discord Gateway/API and the authenticated Fleetview MCP endpoint use TLS.
-    - ports:
-        - port: 443
-          protocol: TCP
     # The dedicated key is accepted only by these three Workspace addresses.
     - to:
         - ipBlock:
@@ -116,6 +112,29 @@ spec:
     matchLabels:
       app.kubernetes.io/name: hermes
   egress:
+    # Feed Cilium's DNS proxy so the HTTPS allowlist below follows current A
+    # and AAAA records instead of opening every destination on TCP 443.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchName: api.github.com
+        - matchName: fleetview.code.davidapps.dev
+        - matchName: id.davidapps.dev
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toEntities:
         - kube-apiserver
       toPorts:

--- a/kubernetes/apps/default/hermes/app/rbac.yaml
+++ b/kubernetes/apps/default/hermes/app/rbac.yaml
@@ -12,12 +12,12 @@ rules:
   - apiGroups: [""]
     resources: [nodes, namespaces, pods, services, persistentvolumeclaims, events]
     verbs: [get, list, watch]
+  # Deliberately omit patch/update on workload controllers and Flux objects.
+  # Kubernetes RBAC cannot restrict a patch to only a rollout or reconcile
+  # annotation, so either permission would also authorize spec replacement.
   - apiGroups: [apps]
     resources: [deployments, statefulsets, daemonsets]
-    verbs: [get, list, watch, patch]
-  - apiGroups: [apps]
-    resources: [deployments/scale, statefulsets/scale]
-    verbs: [get, patch, update]
+    verbs: [get, list, watch]
   - apiGroups: [batch]
     resources: [jobs, cronjobs]
     verbs: [get, list, watch]
@@ -26,10 +26,10 @@ rules:
     verbs: [get, list, watch]
   - apiGroups: [kustomize.toolkit.fluxcd.io]
     resources: [kustomizations]
-    verbs: [get, list, watch, patch]
+    verbs: [get, list, watch]
   - apiGroups: [helm.toolkit.fluxcd.io]
     resources: [helmreleases]
-    verbs: [get, list, watch, patch]
+    verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

- make the GPU namespace default-deny select every pod and disable token automount on its default ServiceAccount
- remove cluster-wide workload/Flux patch and scale permissions from the home Hermes identity; hide the now-disabled home mutation tools
- replace unrestricted TCP 443 egress with Cilium FQDN rules for the exact GitHub, Fleetview, and DavidApps endpoints
- treat arbitrary GPU Job logs as untrusted MCP output

## Security boundary

Kubernetes RBAC cannot constrain patch to only a rollout annotation or a Flux reconcile annotation. Removing those permissions is intentional: retaining them would allow pod-template or HelmRelease-spec replacement and effective privilege escalation. Home cluster observation still works, and the dedicated hermes-gpu Role remains the only home write surface.

This does not implement the source-level approval/credential split. That belongs in DavidIlie/hermes, not this GitOps repository. The follow-up should:

1. give the upstream Agent only a read MCP credential;
2. keep mutation credentials behind a separate broker identity/listener;
3. mint a one-time approval intent only after David's Discord interaction, binding tool name, canonical argument hash, user, nonce, and a short expiry;
4. require and atomically consume that intent inside every mutating MCP handler before calling Kubernetes/media/DavidApps clients;
5. test missing approval, replay, expiry, argument substitution, user mismatch, and concurrent double-spend.

The external davidapps/UK Kubernetes identities also need separate repository changes to replace their long-lived combined read/write tokens. They are intentionally not mixed into this PR.

## Verification

- kustomize build passed for hermes, hermes-agent, hermes-gpu, and the default app tree
- flux-local v8.4.0 test --enable-helm --all-namespaces: **206 passed**
- git diff --check: passed

Review only: no manual apply or Flux reconcile was performed.
