### PR TITLE
fix(grafana): prefer DavidApps login safely

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -23,6 +23,9 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    image:
+      tag: 12.3.10
+      sha: sha256:91032506559aa7477105b5835c5a17475b4909635fbe240bd6aff50512717a5b
     deploymentStrategy:
       type: Recreate
     resources:
@@ -59,7 +62,9 @@ spec:
         name: DavidApps
         enabled: true
         allow_sign_up: true
-        auto_login: false
+        # DavidApps is the normal path; /login?disableAutoLogin=true keeps the
+        # local admin form available as a documented break-glass recovery.
+        auto_login: true
         auth_url: https://id.davidapps.dev/api/auth/oauth2/authorize
         token_url: https://id.davidapps.dev/api/auth/oauth2/token
         api_url: https://id.davidapps.dev/api/auth/oauth2/userinfo
@@ -73,8 +78,15 @@ spec:
         name_attribute_path: name
         email_attribute_path: email
         skip_org_role_sync: true
+      feature_toggles:
+        # Keep the SQL Expressions execution surface off even on patched
+        # versions; this instance does not use it.
+        sqlExpressions: false
       news:
         news_feed_enabled: false
+      security:
+        cookie_secure: true
+        cookie_samesite: lax
     datasources:
       datasources.yaml:
         apiVersion: 1
@@ -400,6 +412,7 @@ spec:
       enabled: true
       ingressClassName: external
       annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "10m"
         gethomepage.dev/enabled: "true"
         gethomepage.dev/group: Monitoring
         gethomepage.dev/name: Grafana


### PR DESCRIPTION
## What changed
- make DavidApps OIDC the normal Grafana login path
- preserve local break-glass at `/login?disableAutoLogin=true`
- upgrade Grafana to patched 12.3.10 and pin its multi-architecture digest
- disable the unused SQL Expressions feature
- require secure SameSite cookies and cap ingress request bodies at 10 MiB

## Safety
- local auth and the local admin account remain enabled for IdP outages
- no secrets changed or exposed
- this PR is GitOps only; live rollout happens after merge/Flux

## Validation
- flux-local v8.4.0: 206/206 resources passed after rebasing on current main
- `git diff --check` passed