### PR TITLE
fix(grafana): correct digest value format

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -25,7 +25,8 @@ spec:
   values:
     image:
       tag: 12.3.10
-      sha: sha256:91032506559aa7477105b5835c5a17475b4909635fbe240bd6aff50512717a5b
+      # The chart prefixes this field with `sha256:` when composing the image.
+      sha: 91032506559aa7477105b5835c5a17475b4909635fbe240bd6aff50512717a5b
     deploymentStrategy:
       type: Recreate
     resources:


### PR DESCRIPTION
The Grafana chart prepends `sha256:` to `image.sha`. PR #715 supplied the full prefixed digest, producing `@sha256:sha256:...` and an `InvalidImageName` pod. This supplies the bare hash expected by chart 10.5.15.

Live failure was read back from the generated Pod before this fix. `git diff --check` passes.