### PR TITLE
fix(ingress): render valid HSTS max age

### DIFF
--- a/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml
@@ -61,7 +61,9 @@ spec:
         set-real-ip-from: 0.0.0.0/0
         compute-full-forwarded-for: "true"
         hide-headers: Server,X-Powered-By
-        hsts-max-age: 31449600
+        # ingress-nginx expects a string; an unquoted YAML number is rendered
+        # as scientific notation and produces a malformed HSTS header.
+        hsts-max-age: "31449600"
         keep-alive-requests: 10000
         keep-alive: 120
         log-format-escape-json: "true"

--- a/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml
@@ -50,7 +50,9 @@ spec:
         enable-real-ip: "true"
         force-ssl-redirect: "true"
         hide-headers: Server,X-Powered-By
-        hsts-max-age: 31449600
+        # ingress-nginx expects a string; an unquoted YAML number is rendered
+        # as scientific notation and produces a malformed HSTS header.
+        hsts-max-age: "31449600"
         keep-alive-requests: 10000
         keep-alive: 120
         log-format-escape-json: "true"


### PR DESCRIPTION
Both ingress controllers stored the HSTS age as a YAML number, which Helm rendered in scientific notation. Browsers received `max-age=3.14496e+07` instead of a valid integer. Quote the value so Nginx emits `max-age=31449600`.

Validation: pinned flux-local v8.4.0 passed 206/206 resources; `git diff --check` passed.