### PR TITLE
feat(grafana): add ZeroCut revenue telemetry

### DIFF
--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-overview.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-overview.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,633 +12,924 @@
       }
     ]
   },
+  "description": "Operational telemetry for ZeroCut. Revenue amounts are positive integer minor-currency units and are always split by currency; never add unlike currencies. Net movement uses the application's explicit credit/debit direction. These signals are useful for operations, not an accounting ledger.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [
     {
-      "type": "link",
+      "includeVars": false,
+      "keepTime": false,
+      "targetBlank": true,
       "title": "Open ZeroCut",
-      "url": "https://zerocut.gg",
-      "targetBlank": true,
-      "includeVars": false,
-      "keepTime": false
+      "type": "link",
+      "url": "https://zerocut.gg"
     },
     {
-      "type": "link",
+      "includeVars": false,
+      "keepTime": false,
+      "targetBlank": true,
       "title": "Repository",
-      "url": "https://github.com/DavidIlie/zerocut",
-      "targetBlank": true,
-      "includeVars": false,
-      "keepTime": false
+      "type": "link",
+      "url": "https://github.com/DavidIlie/zerocut"
     },
     {
-      "type": "link",
-      "title": "Trace search",
-      "url": "/explore?schemaVersion=1&panes=%7B%22trace%22:%7B%22datasource%22:%22tempo%22%7D%7D",
-      "targetBlank": true,
       "includeVars": false,
-      "keepTime": true
+      "keepTime": true,
+      "targetBlank": true,
+      "title": "Trace search",
+      "type": "link",
+      "url": "/explore?schemaVersion=1&panes=%7B%22trace%22:%7B%22datasource%22:%22tempo%22%7D%7D"
     }
   ],
   "liveNow": false,
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "id": 1,
-      "title": "Replica availability",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-davidapps-cluster"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "decimals": 2,
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-davidapps-cluster"
-          },
-          "editorMode": "code",
-          "expr": "sum(kube_deployment_status_replicas_available{namespace=\"personal-projects\",deployment=~\"zerocut\"}) / clamp_min(sum(kube_deployment_spec_replicas{namespace=\"personal-projects\",deployment=~\"zerocut\"}), 1)",
-          "legendFormat": "",
-          "range": false,
-          "instant": true,
-          "refId": "A"
-        }
-      ]
+      "panels": [],
+      "title": "ZeroCut platform payments",
+      "type": "row"
     },
     {
-      "id": 2,
-      "title": "Restarts",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-davidapps-cluster"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Positive amount movements recorded by ZeroCut's own billing ledger in the selected range. Each tile is one product, outcome, provider, mode, and currency. Values are integer minor-currency units; do not add different outcomes or currencies.",
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "color": { "mode": "palette-classic" },
           "decimals": 0,
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
+          "unit": "short"
         },
         "overrides": []
       },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-davidapps-cluster"
-          },
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"personal-projects\",pod=~\"(zerocut)-.*\"}[$__rate_interval]))",
-          "legendFormat": "",
-          "range": false,
+          "expr": "sum by (revenue_product, commerce_outcome, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"platform\"}[$__range]))",
           "instant": true,
+          "legendFormat": "{{revenue_product}} · {{commerce_outcome}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Platform amount movements · selected range",
+      "type": "stat"
     },
     {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Net platform revenue movement in the selected range: explicit credits minus explicit debits. Neutral compensation/lifecycle signals are excluded. Results stay separate by product, provider, mode, and currency and are not a reconciled ledger.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 1 },
       "id": 3,
-      "title": "p95 span latency",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "decimals": 3,
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
-          },
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=~\"zerocut\"}[$__rate_interval])))",
-          "legendFormat": "",
-          "range": false,
+          "expr": "(sum by (revenue_product, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"platform\",revenue_net_direction=\"credit\"}[$__range])) - sum by (revenue_product, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"platform\",revenue_net_direction=\"debit\"}[$__range]))) or sum by (revenue_product, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"platform\",revenue_net_direction=\"credit\"}[$__range])) or (-1 * sum by (revenue_product, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"platform\",revenue_net_direction=\"debit\"}[$__range])))",
           "instant": true,
+          "legendFormat": "{{revenue_product}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Platform net movement · selected range",
+      "type": "stat"
     },
     {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Number of durable platform billing transitions observed in the selected range, split by bounded business dimensions. A count is an operational event count, not an invoice count from an accounting system.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 8 },
       "id": 4,
-      "title": "Span error rate",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "decimals": 2,
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto",
         "wideLayout": true
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
-          },
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "sum(rate(traces_spanmetrics_calls_total{service=~\"zerocut\",status_code=\"STATUS_CODE_ERROR\"}[$__rate_interval])) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=~\"zerocut\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum by (revenue_product, commerce_outcome, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_count\",service_name=\"zerocut\",revenue_stream=\"platform\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{revenue_product}} · {{commerce_outcome}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Platform event count",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Per-second rate of durable platform billing transitions. Use the legend to distinguish successful payments, refunds, disputes, and compensation without combining their meanings.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 16, "x": 8, "y": 8 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (revenue_product, commerce_outcome, commerce_provider, commerce_mode, commerce_currency) (rate({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_count\",service_name=\"zerocut\",revenue_stream=\"platform\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{revenue_product}} · {{commerce_outcome}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Platform payment activity rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "id": 6,
+      "panels": [],
+      "title": "Supporter-to-creator donations",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Positive creator-donation amount movements in the selected range after ZeroCut's durable Stripe or PayPal authority wins. Each tile is one outcome, provider, mode, and currency. Values are integer minor-currency units and are creator funds, not ZeroCut platform revenue.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (commerce_outcome, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{commerce_outcome}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Creator donation movements · selected range",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Net creator-fund movement in the selected range: explicit credits minus explicit debits, with neutral lifecycle signals excluded. Results stay separate by provider, mode, and currency. This is operational flow telemetry, not creator payout accounting.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "(sum by (commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\",revenue_net_direction=\"credit\"}[$__range])) - sum by (commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\",revenue_net_direction=\"debit\"}[$__range]))) or sum by (commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\",revenue_net_direction=\"credit\"}[$__range])) or (-1 * sum by (commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_sum\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\",revenue_net_direction=\"debit\"}[$__range])))",
+          "instant": true,
+          "legendFormat": "{{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Creator donation net movement · selected range",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Number of durable creator-donation transitions in the selected range. Stripe and PayPal are counted only after application authority and retry deduplication.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 23 },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (commerce_outcome, commerce_provider, commerce_mode, commerce_currency) (increase({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_count\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{commerce_outcome}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Creator donation event count",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Per-second rate of durable creator-donation transitions, split by outcome, provider, mode, and currency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 16, "x": 8, "y": 23 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (commerce_outcome, commerce_provider, commerce_mode, commerce_currency) (rate({__name__=~\"zerocut_revenue_amount(_minor_currency_unit)?_count\",service_name=\"zerocut\",revenue_stream=\"creator_donation\",revenue_product=\"creator_donation\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{commerce_outcome}} · {{commerce_provider}} · {{commerce_mode}} · {{commerce_currency}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Creator donation activity rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "id": 11,
+      "panels": [],
+      "title": "Server reliability and runtime",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 31 },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum(kube_deployment_status_replicas_available{namespace=\"personal-projects\",deployment=\"zerocut\"}) / clamp_min(sum(kube_deployment_spec_replicas{namespace=\"personal-projects\",deployment=\"zerocut\"}), 1)",
+          "instant": true,
           "legendFormat": "",
           "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Replica availability",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 31 },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"personal-projects\",pod=~\"zerocut-.*\"}[$__range]))",
           "instant": true,
+          "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Restarts · selected range",
+      "type": "stat"
     },
     {
-      "id": 5,
+      "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+      "description": "p95 latency for server-kind ZeroCut spans generated by Tempo span metrics.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 31 },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{service=\"zerocut\",span_kind=\"SPAN_KIND_SERVER\"}[$__rate_interval])))",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Server p95 latency",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+      "description": "Error-status server spans divided by all server spans over the current rate interval.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 31 },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+          "editorMode": "code",
+          "expr": "sum(rate(traces_spanmetrics_calls_total{service=\"zerocut\",span_kind=\"SPAN_KIND_SERVER\",status_code=\"STATUS_CODE_ERROR\"}[$__rate_interval])) / clamp_min(sum(rate(traces_spanmetrics_calls_total{service=\"zerocut\",span_kind=\"SPAN_KIND_SERVER\"}[$__rate_interval])), 0.000001)",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Server error ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 16,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (span_name) (rate(traces_spanmetrics_calls_total{service=\"zerocut\",span_kind=\"SPAN_KIND_SERVER\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{span_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Server request/span rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 17,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (span_name) (rate(traces_spanmetrics_calls_total{service=\"zerocut\",span_kind=\"SPAN_KIND_SERVER\",status_code=\"STATUS_CODE_ERROR\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{span_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Server error throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 43 },
+      "id": 18,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"personal-projects\",pod=~\"zerocut-.*\",container!=\"POD\",image!=\"\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "CPU by pod",
-      "type": "timeseries",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-davidapps-cluster"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 4
-      },
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
       "fieldConfig": {
         "defaults": {
-          "unit": "cores",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 12,
             "lineWidth": 2,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "bytes"
         },
         "overrides": []
       },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 43 },
+      "id": 19,
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-davidapps-cluster"
-          },
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"personal-projects\",pod=~\"(zerocut)-.*\",container!=\"POD\",image!=\"\"}[$__rate_interval]))",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"personal-projects\",pod=~\"zerocut-.*\",container!=\"POD\",image!=\"\"})",
+          "instant": false,
           "legendFormat": "{{pod}}",
           "range": true,
-          "instant": false,
           "refId": "A"
         }
-      ]
-    },
-    {
-      "id": 6,
+      ],
       "title": "Memory by pod",
-      "type": "timeseries",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-davidapps-cluster"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 4
-      },
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "id": 20,
+      "panels": [],
+      "title": "Browser experience",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "p75 Largest Contentful Paint emitted by Faro, split by exact browser release SHA. The expected flattened field is verified after the first deployment canary.",
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "thresholds" },
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 12,
+            "fillOpacity": 15,
             "lineWidth": 2,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2500 },
+              { "color": "red", "value": 4000 }
+            ]
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 51 },
+      "id": 21,
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-davidapps-cluster"
-          },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
           "editorMode": "code",
-          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"personal-projects\",pod=~\"(zerocut)-.*\",container!=\"POD\",image!=\"\"})",
-          "legendFormat": "{{pod}}",
-          "range": true,
-          "instant": false,
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" kind:\"measurement\" | stats by (_time:5m, app_version) quantile(0.75, lcp) if (lcp:*) as lcp_p75",
+          "legendFormat": "{{app_version}}",
+          "queryType": "statsRange",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "LCP p75 by release",
+      "type": "timeseries"
     },
     {
-      "id": 7,
-      "title": "Request/span throughput",
-      "type": "timeseries",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 12
-      },
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "p75 Interaction to Next Paint emitted by Faro, split by exact browser release SHA.",
       "fieldConfig": {
         "defaults": {
-          "unit": "ops",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "thresholds" },
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 12,
+            "fillOpacity": 15,
             "lineWidth": 2,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 200 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 51 },
+      "id": 22,
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
-          },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
           "editorMode": "code",
-          "expr": "sum by (service, span_name) (rate(traces_spanmetrics_calls_total{service=~\"zerocut\"}[$__rate_interval]))",
-          "legendFormat": "{{service}} · {{span_name}}",
-          "range": true,
-          "instant": false,
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" kind:\"measurement\" | stats by (_time:5m, app_version) quantile(0.75, inp) if (inp:*) as inp_p75",
+          "legendFormat": "{{app_version}}",
+          "queryType": "statsRange",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "INP p75 by release",
+      "type": "timeseries"
     },
     {
-      "id": 8,
-      "title": "Error throughput",
-      "type": "timeseries",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 12
-      },
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "p75 Cumulative Layout Shift emitted by Faro, split by exact browser release SHA.",
       "fieldConfig": {
         "defaults": {
-          "unit": "ops",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "thresholds" },
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 12,
+            "fillOpacity": 15,
             "lineWidth": 2,
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          },
+          "unit": "none"
         },
         "overrides": []
       },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 51 },
+      "id": 23,
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
-          },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
           "editorMode": "code",
-          "expr": "sum by (service, span_name) (rate(traces_spanmetrics_calls_total{service=~\"zerocut\",status_code=\"STATUS_CODE_ERROR\"}[$__rate_interval]))",
-          "legendFormat": "{{service}} · {{span_name}}",
-          "range": true,
-          "instant": false,
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" kind:\"measurement\" | stats by (_time:5m, app_version) quantile(0.75, cls) if (cls:*) as cls_p75",
+          "legendFormat": "{{app_version}}",
+          "queryType": "statsRange",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "CLS p75 by release",
+      "type": "timeseries"
     },
     {
-      "id": 9,
-      "title": "Application log volume",
-      "type": "timeseries",
-      "datasource": {
-        "type": "victoriametrics-logs-datasource",
-        "uid": "victoria-logs"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 20
-      },
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "Browser exception/error volume split by exact deployed browser SHA. URLs and messages are privacy-scrubbed by the telemetry package before ingestion.",
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "bars",
             "fillOpacity": 35,
             "lineWidth": 1,
             "showPoints": "never",
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
-            }
-          }
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 59 },
+      "id": 24,
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": [
-            "sum"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "victoriametrics-logs-datasource",
-            "uid": "victoria-logs"
-          },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
           "editorMode": "code",
-          "expr": "_stream: {k_namespace_name=\"personal-projects\", cluster=\"davidapps-cluster\"} app:~\"zerocut\" | stats by (app) count()",
-          "legendFormat": "{{app}}",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" kind:~\"exception|log\" _msg:~\"(?i)(error|exception|fatal|panic)\" | stats by (_time:5m, app_version, kind) count()",
+          "legendFormat": "{{app_version}} · {{kind}}",
           "queryType": "statsRange",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Browser errors by release",
+      "type": "timeseries"
     },
     {
-      "id": 10,
-      "title": "Recent error logs",
-      "type": "logs",
-      "datasource": {
-        "type": "victoriametrics-logs-datasource",
-        "uid": "victoria-logs"
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 67 },
+      "id": 25,
+      "panels": [],
+      "title": "Logs, trace correlation, and active release",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "Server container logs and browser Faro records. Browser and server series remain distinct.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 35,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
       },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 20
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 68 },
+      "id": 26,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+          "editorMode": "code",
+          "expr": "_stream: {k_namespace_name=\"personal-projects\", cluster=\"davidapps-cluster\"} app:\"zerocut\" | stats by (_time:5m, app) count()",
+          "legendFormat": "server · {{app}}",
+          "queryType": "statsRange",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" | stats by (_time:5m, app_name) count()",
+          "legendFormat": "browser · {{app_name}}",
+          "queryType": "statsRange",
+          "refId": "B"
+        }
+      ],
+      "title": "Application signal volume",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "Recent server and browser errors. VictoriaLogs-derived trace IDs open the correlated Tempo trace through the datasource link.",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 68 },
+      "id": 27,
       "options": {
         "dedupStrategy": "none",
         "enableInfiniteScrolling": true,
@@ -655,119 +943,80 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "victoriametrics-logs-datasource",
-            "uid": "victoria-logs"
-          },
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
           "editorMode": "code",
-          "expr": "_stream: {k_namespace_name=\"personal-projects\", cluster=\"davidapps-cluster\"} app:~\"zerocut\" _msg:~\"(?i)(error|exception|fatal|panic)\" | fields _msg, _time, app, k_pod_name, k_container_name, trace_id | sort desc | limit 200",
+          "expr": "_stream: {k_namespace_name=\"personal-projects\", cluster=\"davidapps-cluster\"} app:\"zerocut\" _msg:~\"(?i)(error|exception|fatal|panic)\" | fields _msg, _time, app, k_pod_name, k_container_name, trace_id, span_id | sort desc | limit 200",
           "queryType": "range",
           "refId": "A"
+        },
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" kind:~\"exception|log\" _msg:~\"(?i)(error|exception|fatal|panic)\" | fields _msg, _time, kind, app_name, app_version, page_url, trace_id, span_id | sort desc | limit 200",
+          "queryType": "range",
+          "refId": "B"
         }
-      ]
+      ],
+      "title": "Recent correlated errors",
+      "type": "logs"
     },
     {
-      "id": 11,
-      "title": "Active release and container image",
-      "type": "table",
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Mixed --"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 30
-      },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Server and browser trace resources carry the exact 40-character deployed Git SHA as service_version. Click a release row to open that immutable commit; container image identity is retained alongside it.",
       "fieldConfig": {
         "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
           "links": [
             {
+              "targetBlank": true,
               "title": "Open active commit",
-              "url": "https://github.com/DavidIlie/zerocut/commit/${__field.labels.service_version}",
-              "targetBlank": true
+              "url": "https://github.com/DavidIlie/zerocut/commit/${__field.labels.service_version}"
             }
-          ],
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          }
+          ]
         },
         "overrides": []
       },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 78 },
+      "id": 28,
       "options": {
-        "showHeader": true,
         "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
-        },
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
         "sortBy": []
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-davidapps-cluster"
-          },
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "max by (namespace, pod, container, image, image_id) (kube_pod_container_info{namespace=\"personal-projects\",pod=~\"(zerocut)-.*\"})",
+          "expr": "max by (namespace, pod, container, image, image_id) (kube_pod_container_info{namespace=\"personal-projects\",pod=~\"zerocut-.*\"})",
+          "instant": true,
           "legendFormat": "{{pod}} / {{container}}",
           "range": false,
-          "instant": true,
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
-          },
+          "datasource": { "type": "prometheus", "uid": "prometheus-home-cluster" },
           "editorMode": "code",
-          "expr": "max by (service, service_version) (traces_target_info{service=~\"zerocut\"})",
+          "expr": "max by (service, service_version) (traces_target_info{service=~\"zerocut|zerocut-web\",service_version!=\"\"})",
+          "instant": true,
           "legendFormat": "{{service}} @ {{service_version}}",
           "range": false,
-          "instant": true,
           "refId": "B"
         }
-      ]
+      ],
+      "title": "Active release and container image",
+      "type": "table"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 41,
-  "tags": [
-    "apps",
-    "zerocut",
-    "otel"
-  ],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": [
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h"
-    ]
-  },
+  "schemaVersion": 42,
+  "tags": ["apps", "zerocut", "otel", "revenue"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": { "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h"] },
   "timezone": "browser",
-  "title": "ZeroCut / Production overview",
+  "title": "ZeroCut / Revenue and reliability",
   "uid": "zerocut-overview",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

- expand the existing ZeroCut Grafana dashboard in its existing Apps / ZeroCut folder
- separate platform revenue from supporter-to-creator donations
- show credits, debits, net movement, event counts, and activity rates without combining currencies
- add server RED/resource panels, browser Web Vitals/errors, logs, traces, and release-to-GitHub links
- query ZeroCut runtime and revenue metrics from prometheus-davidapps-cluster, with Tempo-derived span metrics remaining on prometheus-home-cluster

## Validation

- jq dashboard validation and structural checks
- all 18 PromQL targets parsed against the live datasource after variable substitution
- all 8 LogsQL targets parsed; the server selector returns current ZeroCut logs
- kustomize build kubernetes/apps/observability/grafana/app
- git diff --check
- no PostHog references

## Companion PRs

- ZeroCut instrumentation: https://github.com/DavidIlie/zerocut/pull/25
- DavidApps exporter wiring: https://github.com/DavidIlie/davidapps-cluster/pull/227

Revenue panels remain intentionally empty until the canary emits the new series; verify actual labels and units after deployment before treating them as operational truth.