### PR TITLE
fix(grafana): restore valid UniFi Client DPI dashboard

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -301,8 +301,8 @@ spec:
             - { name: DS_PROMETHEUS, value: prometheus-home-cluster }
         client-dpi:
           # renovate: depName="UniFi-Poller: Client DPI - Prometheus"
-          gnetId: 11316
-          revision: 9
+          gnetId: 11310
+          revision: 5
           datasource:
             - { name: DS_PROMETHEUS, value: prometheus-home-cluster }
       kubernetes:


### PR DESCRIPTION
## Summary

- replace the invalid UniFi Client DPI dashboard import 11316/revision 9, which returns HTTP 404
- restore the valid 11310/revision 5 import under Network / UniFi
- retain only one Client DPI dashboard, avoiding the prior duplicate-UID collision

## Validation

- upstream dashboard download returns HTTP 200
- kustomize build kubernetes/apps/observability/grafana/app
- targeted flux-local Grafana render: 2/2 passed
- git diff --check