### PR TITLE
feat(cache): validate Garage-backed Actions cache

### DIFF
--- a/kubernetes/apps/ci-cache-canary/cache-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ci-cache-canary/cache-server/app/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gha-cache-canary
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: github-actions-cache-server
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    replicaCount: 1
+    config:
+      apiBaseUrl: http://gha-cache-canary-github-actions-cache-server.ci-cache-canary.svc.cluster.local:3000
+      enableDirectDownloads: true
+      cacheCleanupOlderThanDays: 7
+      cacheMaxSizeBytes: "5368709120"
+      orphanedStorageGracePeriodHours: 1
+      storage:
+        driver: s3
+        s3:
+          socketTimeoutMs: 30000
+      db:
+        driver: sqlite
+        sqlite:
+          path: /data/cache-server.db
+    existingSecret: gha-cache-canary-s3
+    persistentVolumeClaim:
+      storage: 2Gi
+      storageClassName: openebs-hostpath
+    serviceAccount:
+      automount: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    extraEnv:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: WHEN_REQUIRED
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: WHEN_REQUIRED

--- a/kubernetes/apps/ci-cache-canary/cache-server/app/kustomization.yaml
+++ b/kubernetes/apps/ci-cache-canary/cache-server/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ci-cache-canary/cache-server/app/ocirepository.yaml
+++ b/kubernetes/apps/ci-cache-canary/cache-server/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: github-actions-cache-server
+spec:
+  interval: 30m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.1.3
+    digest: sha256:daa902589851ac26508d391b056f92eb9630e5d47422cf937a9714688a62d339
+  url: oci://ghcr.io/falcondev-oss/charts/github-actions-cache-server

--- a/kubernetes/apps/ci-cache-canary/cache-server/app/servicemonitor.yaml
+++ b/kubernetes/apps/ci-cache-canary/cache-server/app/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gha-cache-canary
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: gha-cache-canary
+      app.kubernetes.io/name: github-actions-cache-server
+  endpoints:
+    - port: cache
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/kubernetes/apps/ci-cache-canary/cache-server/ks.yaml
+++ b/kubernetes/apps/ci-cache-canary/cache-server/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ci-cache-canary-server
+  namespace: ci-cache-canary
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      app.kubernetes.io/part-of: ci-cache-canary
+  dependsOn:
+    - name: ci-cache-canary-garage
+  interval: 30m
+  retryInterval: 1m
+  path: ./kubernetes/apps/ci-cache-canary/cache-server/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ci-cache-canary
+  timeout: 10m
+  wait: true

--- a/kubernetes/apps/ci-cache-canary/garage/app/admin-token.sops.yaml
+++ b/kubernetes/apps/ci-cache-canary/garage/app/admin-token.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-admin-token
+type: Opaque
+stringData:
+  admin-token: ENC[AES256_GCM,data:ye55JTAt2cxss86jFDR8w7cX78dEka9XURXRaWqakSUiwZ7z/F+VF8nWZ9SGmXxHUF83cfZGNRdDqgGgtQSEpg==,iv:Y81Uty5Ixr5MlalTzxFK1oYkI1dwVfP55b/uWkB7ds0=,tag:juf1UxiPpM1/Tvu50bhRRA==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpaWpOZitXUzVSSnJ0R2xp
+        eWpSTkpkK0dvb3czUmsrVUdLOWZ0bjhuMWpnCkVLUW5YMmkvaU1neHBPbzlJb1BF
+        Y0t4b0grMko1eUZUQmhCQ2t1aSt5WXMKLS0tIFc2MzN1NTk0K3dGN1JIdE4rTHhq
+        OTlLdHNhVE9jdExxUWdLYjhDN1hjalkKy+Kwkt3kfUlvx2tG5CZgeeikrGu3csUF
+        eyf6rH6LiN8wzNALiLttKi0ZsQcfTGN30hMXLkCKT4yB6kRciI3aWg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-17T18:34:24Z"
+  mac: ENC[AES256_GCM,data:HIPDRwIjoWrKc0prY676KW0Ti/if1VjN75h954IWSvvgHphDKLYwexOgeJHkooMyyvbUrottYXzy48qYA+dFCVwMXoFcKbj8svxlUqaglOv4eVc8sAP1mVFTiESR6j2DkDKekQ6o7uWJhAXaA/EUCja6zFfxIFlvwI/R68KJy0w=,iv:tJmd55ly8F/wwWV/E4fBPas+BxZ0V7h8MzJeGh2sww0=,tag:BpJIip2eyPmFQgewbBDjEg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/ci-cache-canary/garage/app/bucket.yaml
+++ b/kubernetes/apps/ci-cache-canary/garage/app/bucket.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: gha-cache-canary
+spec:
+  clusterRef:
+    name: ci-cache-canary
+  quotas:
+    maxSize: 6Gi
+    maxObjects: 10000
+  lifecycle:
+    rules:
+      - id: expire-canary-cache
+        status: Enabled
+        expirationDays: 7
+        abortIncompleteMultipartUploadDays: 1

--- a/kubernetes/apps/ci-cache-canary/garage/app/cluster.yaml
+++ b/kubernetes/apps/ci-cache-canary/garage/app/cluster.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: ci-cache-canary
+spec:
+  image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+  zone: home-canary
+  deletionPolicy: Destroy
+  replication:
+    factor: 1
+    consistencyMode: consistent
+  storage:
+    replicas: 1
+    metadata:
+      size: 2Gi
+      storageClassName: openebs-hostpath
+    data:
+      size: 8Gi
+      storageClassName: openebs-hostpath
+    pvcRetentionPolicy:
+      whenDeleted: Delete
+      whenScaled: Delete
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+  network:
+    rpcBindPort: 3901
+    service:
+      type: ClusterIP
+  s3Api:
+    bindPort: 3900
+    region: ci-cache
+  webApi:
+    enabled: false
+  admin:
+    bindPort: 3903
+    adminTokenSecretRef:
+      name: garage-admin-token
+      key: admin-token
+  database:
+    engine: lmdb
+  monitoring:
+    enabled: true
+    interval: 30s

--- a/kubernetes/apps/ci-cache-canary/garage/app/key.yaml
+++ b/kubernetes/apps/ci-cache-canary/garage/app/key.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: gha-cache-canary
+spec:
+  clusterRef:
+    name: ci-cache-canary
+  name: GitHub Actions cache canary
+  secretTemplate:
+    name: gha-cache-canary-s3
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+    endpointKey: AWS_ENDPOINT_URL
+    regionKey: AWS_REGION
+    includeEndpoint: true
+    includeRegion: true
+    bucketNameKey: STORAGE_S3_BUCKET
+    includeBucketName: true
+  bucketPermissions:
+    - bucketRef:
+        name: gha-cache-canary
+      read: true
+      write: true

--- a/kubernetes/apps/ci-cache-canary/garage/app/kustomization.yaml
+++ b/kubernetes/apps/ci-cache-canary/garage/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./admin-token.sops.yaml
+  - ./cluster.yaml
+  - ./bucket.yaml
+  - ./key.yaml

--- a/kubernetes/apps/ci-cache-canary/garage/ks.yaml
+++ b/kubernetes/apps/ci-cache-canary/garage/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ci-cache-canary-garage
+  namespace: ci-cache-canary
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      app.kubernetes.io/part-of: ci-cache-canary
+  dependsOn:
+    - name: garage-operator
+      namespace: garage-system
+  interval: 30m
+  retryInterval: 1m
+  path: ./kubernetes/apps/ci-cache-canary/garage/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ci-cache-canary
+  timeout: 10m
+  wait: true

--- a/kubernetes/apps/ci-cache-canary/kustomization.yaml
+++ b/kubernetes/apps/ci-cache-canary/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ci-cache-canary
+components:
+  - ../../flux/components/namespace
+  - ../../flux/components/sops
+resources:
+  - ./garage/ks.yaml
+  - ./cache-server/ks.yaml

--- a/kubernetes/apps/garage-system/garage-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/garage-system/garage-operator/app/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: garage-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: garage-operator
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    # home-cluster is a single-node compatibility canary. Production uses
+    # three leader-elected replicas with required host anti-affinity.
+    replicaCount: 1
+    defaultGarageImage: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+    leaderElection:
+      enabled: true
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+    prometheusRules:
+      enabled: true
+    webhooks:
+      enabled: true
+      failurePolicy: Fail
+      certManager:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/garage-system/garage-operator/app/kustomization.yaml
+++ b/kubernetes/apps/garage-system/garage-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/garage-system/garage-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/garage-system/garage-operator/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: garage-operator
+spec:
+  interval: 30m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.7.5
+    digest: sha256:e640b642c1747b90cb8d9d561f0cf3417ce1a7c69b23ba5d25c2a4f929ef022e
+  url: oci://ghcr.io/rajsinghtech/charts/garage-operator

--- a/kubernetes/apps/garage-system/garage-operator/ks.yaml
+++ b/kubernetes/apps/garage-system/garage-operator/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-operator
+  namespace: garage-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+    - name: prometheus-operator-crds
+      namespace: observability
+  interval: 30m
+  retryInterval: 1m
+  path: ./kubernetes/apps/garage-system/garage-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: garage-system
+  timeout: 10m
+  wait: true

--- a/kubernetes/apps/garage-system/kustomization.yaml
+++ b/kubernetes/apps/garage-system/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: garage-system
+components:
+  - ../../flux/components/namespace
+  - ../../flux/components/sops
+resources:
+  - ./garage-operator/ks.yaml


### PR DESCRIPTION
Installs the pinned Garage operator 0.7.5 on home-cluster and a disposable single-node compatibility canary using Garage 2.3.0 plus github-actions-cache-server 9.7.0/chart 1.1.3. The canary uses a 6 GiB lifecycle-limited S3 bucket, generated least-privilege credentials, checksum compatibility settings, direct downloads, and Prometheus metrics. This is the required core-infrastructure gate before a three-node production deployment. Validation: both Kustomize roots, both pinned Helm renders, encrypted SOPS secret, and pinned flux-local v8.4.0 (211 passed).