### PR TITLE
chore(ci): use canonical actions runner

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,7 @@ jobs:
   configure:
     if: ${{ github.repository == 'onedr0p/cluster-template' }}
     name: configure
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'davidapps-linux-x64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || 'davidapps-ubuntu' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   test:
     name: Flux Local Test
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'davidapps-linux-x64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || 'davidapps-ubuntu' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -28,7 +28,7 @@ jobs:
 
   diff:
     name: Flux Local Diff
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'davidapps-linux-x64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || 'davidapps-ubuntu' }}
     permissions:
       pull-requests: write
     strategy:
@@ -93,7 +93,7 @@ jobs:
     needs: ["test", "diff"]
     if: ${{ always() }}
     name: Flux Local successful
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'davidapps-linux-x64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || 'davidapps-ubuntu' }}
     steps:
       - name: Check flux-local status
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   label-sync:
     name: Label Sync
-    runs-on: davidapps-linux-x64
+    runs-on: davidapps-ubuntu
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   labeler:
     name: Labeler
-    runs-on: davidapps-linux-x64
+    runs-on: davidapps-ubuntu
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mise.yaml
+++ b/.github/workflows/mise.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   mise:
     name: upgrade-tools
-    runs-on: davidapps-linux-x64
+    runs-on: davidapps-ubuntu
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: davidapps-linux-x64
+    runs-on: davidapps-ubuntu
     steps:
       - name: Get Previous Release Tag and Determine Next Tag
         id: determine-next-tag


### PR DESCRIPTION
Routes owned Linux CI jobs through the canonical davidapps-ubuntu fleet. Fork-origin pull requests remain on pinned ubuntu-24.04 where supported. Validation: YAML parse, actionlint v1.7.12, and git diff --check.