### PR TITLE
fix(garage): restore operator for finalizer recovery

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./envoy-gateway-system
   - ./external-services
   - ./flux-system
+  - ./garage-system
   - ./infastructure
   - ./kube-system
   - ./media


### PR DESCRIPTION
## Summary

- add only `./garage-system` to the explicit applications root
- restore the Garage operator so it can process the already-terminating `ci-cache-canary` GarageCluster finalizer
- do not re-enable the cache server, GarageCluster source, home runner, or any other application

## Why this prerequisite exists

Commit `70a6e0ed` introduced the first explicit applications root without `garage-system` or `ci-cache-canary`. Flux consequently pruned the operator before the GarageCluster finalizer completed. Reinstalling the operator is safer than manually stripping the finalizer.

After merge and reconciliation, wait for the terminating GarageCluster and generated Services/secrets/configmaps to disappear, verify no Garage custom resources remain, then continue the staged cleanup in #732.

## Validation

- `kustomize build kubernetes/apps/garage-system` — 3 objects
- `kustomize build kubernetes/apps` — 189 objects
- pinned `ghcr.io/allenporter/flux-local:v8.4.0` — **203 passed**
- exact diff: one file, one insertion

No live cluster mutation was performed by this branch.