### PR TITLE
feat(seedyn): deploy private upload service

### DIFF
--- a/kubernetes/apps/default/homepage/app/services.yaml
+++ b/kubernetes/apps/default/homepage/app/services.yaml
@@ -136,6 +136,10 @@
         icon: n8n.png
         href: https://n8n.davidhome.ro
         description: Workflow Automation
+    - Seedyn:
+        icon: mdi-cloud-upload-outline
+        href: https://seedyn.dave.tips
+        description: Private upload library
 
 - Infrastructure:
     - Unifi Controller:

--- a/kubernetes/apps/default/image-automations/app/kustomization.yaml
+++ b/kubernetes/apps/default/image-automations/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ./error-pages.yaml
   - ./personal-dashboard.yaml
+  - ./seedyn.yaml
   - ./uber-item-viewer.yaml

--- a/kubernetes/apps/default/image-automations/app/seedyn.yaml
+++ b/kubernetes/apps/default/image-automations/app/seedyn.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: seedyn
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: seedyn
+  filterTags:
+    pattern: "^.+-[a-f0-9]+-(?P<ts>[0-9]+)"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: seedyn
+  namespace: flux-system
+spec:
+  image: ghcr.io/davidilie/seedyn
+  interval: 1m0s
+  secretRef:
+    name: docker-regcred

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ./paperless/ks.yaml
   - ./stirling-pdf/ks.yaml
   # - ./n8n/ks.yaml
+  - ./seedyn/ks.yaml
   - ./error-pages/ks.yaml
   - ./image-automations/ks.yaml
   - ./hermes-gpu/ks.yaml

--- a/kubernetes/apps/default/seedyn/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seedyn/app/helmrelease.yaml
@@ -1,0 +1,181 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bernd-schorgers/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app seedyn
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      seedyn:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          terminationGracePeriodSeconds: 45
+          imagePullSecrets:
+            - name: docker-regcred
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.4
+            envFrom: &envFrom
+              - secretRef:
+                  name: seedyn-secret
+          migrate:
+            image:
+              repository: &image ghcr.io/davidilie/seedyn # {"$imagepolicy": "flux-system:seedyn:name"}
+              tag: &tag master-cdda7749-1787139871 # {"$imagepolicy": "flux-system:seedyn:tag"}
+            command: ["pnpm"]
+            args: ["db:migrate"]
+            envFrom: *envFrom
+            securityContext: &securityContext
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+              seccompProfile:
+                type: RuntimeDefault
+        containers:
+          app:
+            image:
+              repository: *image
+              tag: *tag
+            envFrom: *envFrom
+            env:
+              NODE_ENV: production
+              APP_URL: https://seedyn.dave.tips
+              CDN_URL: https://i.dave.tips
+              APP_HOSTS: seedyn.dave.tips
+              MEDIA_HOSTS: i.dave.tips
+              REDIS_URL: redis://dragonfly.databases.svc.cluster.local:6379
+              MINIO_URL: cdn.davidapps.dev
+              MINIO_PORT: "443"
+              MINIO_SECURE: "true"
+              MINIO_BUCKET: seedyn
+              SEEDYN_DEV_AUTH: "false"
+              TRUSTED_PROXY_HOPS: "1"
+              POD_IP:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz
+                    port: &port 3000
+                  failureThreshold: 30
+                  periodSeconds: 2
+                  timeoutSeconds: 1
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz
+                    port: *port
+                  periodSeconds: 15
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/readyz
+                    port: *port
+                  periodSeconds: 5
+                  timeoutSeconds: 4
+                  failureThreshold: 2
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["sleep", "10"]
+            securityContext: *securityContext
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+                ephemeral-storage: 256Mi
+              limits:
+                memory: 1Gi
+                ephemeral-storage: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    persistence:
+      next-cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/.next/cache
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        className: external
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "external.davidhome.ro"
+          gethomepage.dev/enabled: "false"
+          gatus.home-operations.com/endpoint: |-
+            name: Seedyn
+            group: Utilities
+            url: https://seedyn.dave.tips/api/healthz
+            interval: 1m
+            conditions: ["[STATUS] == 200"]
+          nginx.ingress.kubernetes.io/proxy-body-size: "65m"
+          nginx.ingress.kubernetes.io/proxy-buffering: "off"
+          nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+          nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+        hosts:
+          - host: &appHost seedyn.dave.tips
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+          - host: &mediaHost i.dave.tips
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *appHost
+              - *mediaHost

--- a/kubernetes/apps/default/seedyn/app/kustomization.yaml
+++ b/kubernetes/apps/default/seedyn/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/seedyn/app/secret.sops.yaml
+++ b/kubernetes/apps/default/seedyn/app/secret.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: seedyn-secret
+  namespace: default
+type: Opaque
+stringData:
+  AUTH_SECRET: ENC[AES256_GCM,data:wXvteQzkaDqrIGk5Lm0Cv2l0icx+iKYENOS2n00sRY9kJg1TDUi8SyIzqTA1H4aEtEZQSTsobZKlkQ8qirnxXg==,iv:0qY57xdk2gQ/7l1bWCSl16Yv1cd4LrcuaFMi8xtatkk=,tag:RePGdM04TJE2QJTgcw9Bhg==,type:str]
+  AUTH_DAVIDAPPS_SECRET: ENC[AES256_GCM,data:kYywbYk+vyF/slA/SZsXgsWPLMeNwiJpQIG8ywrjaaJhp6Y8mzkn3QuVhA==,iv:N7wWjnFilg9V7MBLEGyxHYJJPa27ES/r0xPW5eU91Fg=,tag:QhwRgy5RXEp+6S7XZsIwuA==,type:str]
+  DATABASE_URL: ENC[AES256_GCM,data:hJ7WAzG3tE6K3t3W55SUphIQqM2YXzBuBzRdSwR08bOsD6Dv5QbE5/ODC3wcyI31FdoPuydpjUtbCRIEGXR4QXANETwx49P6ewJVKppypff1mrXYcwo1inMDURIdWDUNEA9hjCYUo/oEuQ8e4+2BeEqLGnhBrtM0lo4Im/psLMoknVY=,iv:8VD3XiPZohGoFJ45VQ68Oo/8jBoiI0Egb6EEYjy4SNo=,tag:pGRq7WvwUNSUmjMyqOIVfg==,type:str]
+  MINIO_KEY_ID: ENC[AES256_GCM,data:yYnITbHgRjLlZNbW5HCDRu6Xaw==,iv:rpGOon794RrEFhmSUsgMiQWhwK10KTdj3IMA2U6tBFM=,tag:dwAR+pC1PGNS8WUg3FBUMQ==,type:str]
+  MINIO_PASSWORD: ENC[AES256_GCM,data:q85g2cd17z/46xqBtX/9ekBwGnQLmlUGtED/fYUGFAaHC2+NFc54laz1wA==,iv:5gYKxd6UEdxcWf45TdXR84nVCYQJiCjwl/B2FfR1UYs=,tag:W4UeaMAkaoTXHj8A2KcTvA==,type:str]
+  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:YBC1Gaau,iv:YNIIP4m0OiT9JW2zuUUq9eOA+H8pVW6J/6bJ+MTNd6M=,tag:IbpAlckoGI7pfbyBtUpFCg==,type:str]
+  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:+jWAbYaMLn7NUiLqIF8DFEdmP0L1//jSoGDzoSB75GB3i8pSucYXYVs=,iv:/U+UR4L8pOVZmgZnyz+uRAh/GeUSwTyCe6guFy0LuwM=,tag:iugXMXLTs9UFn6lvohGaIQ==,type:str]
+  INIT_POSTGRES_USER: ENC[AES256_GCM,data:gDo8Ghi6,iv:tX7l1igFZ0DxZPkkbW2Xw4dgik8SUcC+lGfDlE+z0wE=,tag:U935ufPW6DOsiaHZLZc9yA==,type:str]
+  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:a6NxTw1NxjlvLXubywaUPYS08ir9xSS/v1zGPR/UG6jAadOctlUg2ppYdw==,iv:iVS4OwqbjB5jsHvKAcPFURY1wVhpGcFqw6vMcLzwibw=,tag:V6MAAo0dhv04WZXedAVMqw==,type:str]
+  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:2DbryAV9wxbP01z+daA=,iv:6dRp7IOAabV7QhiCb8WgDvwBQhAV2OXlzxrpO6x3H+0=,tag:wc+M+Q6uspnTffHZOotLlA==,type:str]
+  AUTH_DAVIDAPPS_ID: ENC[AES256_GCM,data:DIVCUuM7XfDADCSyZDMj85gZ3WhhU4D4kkuPBFnY2Kw=,iv:SLyZ7FDTlullUzf8p/fzE2kflsluBfuTcSWPqdlU7uA=,tag:HXhd+QRl3Qq1hEw3Zr9gmw==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmdnZmYUdyZHl0cHlkWnQ2
+        UEtSNGMvSk0ySzhld1A2b3ZIeDZaeVg1c1E0CkNFM3dVQitVLzBwbTFZN3lzYkpp
+        bGw5bElxNU8yZVNrMXRhM0FmREhsN1kKLS0tIFovRnArYnJDc3c2RWRyTmNYMWtv
+        UUpRTXpSSnVpcGVBUFozajEzN1JpMWMKpviwQ2suoL4diAwl9gC/bOs54oRDzP0Q
+        hfL7sa0OgsgfGifJr7ndGqdomXGShR0w+Y1jhTahgiyuWazqqAS+TA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-19T10:53:36Z"
+  mac: ENC[AES256_GCM,data:qg6lFNuI7DXMTWP5QcCsyyxO7MghWXcdtvTcUNn6VPxUFOaA/4Wt5zKRMwhZxYKdunfP4QgRaToEn968e+yemhTzmatcXUqKSWZvNKEwxr6HoGLR+OJsBIErlvVciu50o0S82zRSClxPA7RlojEJzSLIsBAOJEEMOcWjDq/b8wA=,iv:oKQcjTedhif3XUtjgyWwUGn5FdJSF5HuRqsoXYz3GN0=,tag:R3eg7Ho6lLSfxiIJv1axbA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/default/seedyn/ks.yaml
+++ b/kubernetes/apps/default/seedyn/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app seedyn
+  namespace: &namespace default
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: databases
+    - name: dragonfly-cluster
+      namespace: databases
+  path: ./kubernetes/apps/default/seedyn/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

- deploy Seedyn to the existing `default` namespace
- route `seedyn.dave.tips` and `i.dave.tips` to one Next.js Service
- use the existing `postgres17` CloudNativePG cluster and shared Dragonfly
- connect to a dedicated private, versioned bucket on the central DavidApps MinIO
- run database creation and Prisma migrations before application startup
- add liveness, dependency readiness, Gatus, Homepage, and Flux image automation
- run as non-root with a read-only root filesystem and bounded writable scratch space

## Infrastructure impact

This does not create a PostgreSQL cluster, Redis instance, MinIO deployment,
persistent volume, or second CDN application. The application Secret is
SOPS-encrypted; no plaintext credential is present in the repository or PR.

## Validation

- immutable `linux/amd64` image exists at `master-d9b06cb1-1787071275`
- Seedyn Kustomize render completed
- Seedyn Flux target: 2/2 checks passed
- full Flux graph: 203/203 checks passed
- SOPS status reports encrypted
- staged secret scan found no credential (the public OIDC client ID is the only generic-key false positive)
- application unit, integration, development E2E, production E2E, Docker build/runtime, and dependency-audit gates passed locally

## Rollout checks after merge

- Flux Kustomization and HelmRelease Ready
- init-db and Prisma migration complete
- pod readiness succeeds against PostgreSQL, Dragonfly, and MinIO
- both public domains obtain TLS and return the expected host-specific behavior
- OIDC sign-in and an upload/media Range smoke pass
