### PR TITLE
fix(seedyn): run migrations without corepack

### DIFF
--- a/kubernetes/apps/default/seedyn/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seedyn/app/helmrelease.yaml
@@ -45,8 +45,13 @@ spec:
             image:
               repository: &image ghcr.io/davidilie/seedyn # {"$imagepolicy": "flux-system:seedyn:name"}
               tag: &tag master-cdda7749-1787139871 # {"$imagepolicy": "flux-system:seedyn:tag"}
-            command: ["pnpm"]
-            args: ["db:migrate"]
+            command: ["node"]
+            args:
+              - scripts/run-command-with-next-env.mjs
+              - node
+              - node_modules/prisma/build/index.js
+              - migrate
+              - deploy
             envFrom: *envFrom
             securityContext: &securityContext
               allowPrivilegeEscalation: false


### PR DESCRIPTION
Run the bundled Prisma CLI directly through Seedyn’s env-loading Node wrapper. This keeps the init container compatible with the read-only root filesystem by avoiding Corepack's writable cache requirement.

Verified against the published linux/amd64 image with `--read-only`, and rendered the Seedyn Kustomization locally.