### PR TITLE
feat(seedyn): add S3 credential master secret

### DIFF
--- a/kubernetes/apps/default/seedyn/app/secret.sops.yaml
+++ b/kubernetes/apps/default/seedyn/app/secret.sops.yaml
@@ -16,6 +16,7 @@ stringData:
   INIT_POSTGRES_PASS: ENC[AES256_GCM,data:a6NxTw1NxjlvLXubywaUPYS08ir9xSS/v1zGPR/UG6jAadOctlUg2ppYdw==,iv:iVS4OwqbjB5jsHvKAcPFURY1wVhpGcFqw6vMcLzwibw=,tag:V6MAAo0dhv04WZXedAVMqw==,type:str]
   INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:2DbryAV9wxbP01z+daA=,iv:6dRp7IOAabV7QhiCb8WgDvwBQhAV2OXlzxrpO6x3H+0=,tag:wc+M+Q6uspnTffHZOotLlA==,type:str]
   AUTH_DAVIDAPPS_ID: ENC[AES256_GCM,data:DIVCUuM7XfDADCSyZDMj85gZ3WhhU4D4kkuPBFnY2Kw=,iv:SLyZ7FDTlullUzf8p/fzE2kflsluBfuTcSWPqdlU7uA=,tag:HXhd+QRl3Qq1hEw3Zr9gmw==,type:str]
+  S3_MASTER_SECRET: ENC[AES256_GCM,data:Z8W+NksBsAgsIfnl/sy4wfmdGQtYMEdpukVzEMXDaopD0zWfdQ2DHMTcSPS3emb84jqhOmKacsvp3oy9wltBCA==,iv:fPeM0/5BqNuZWZ9jCZEnevlQbkHeFOH8OoeOrkn5mBo=,tag:9cEQddlN6LKbmZIzJ6p1UQ==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -27,8 +28,8 @@ sops:
         UUpRTXpSSnVpcGVBUFozajEzN1JpMWMKpviwQ2suoL4diAwl9gC/bOs54oRDzP0Q
         hfL7sa0OgsgfGifJr7ndGqdomXGShR0w+Y1jhTahgiyuWazqqAS+TA==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-19T10:53:36Z"
-  mac: ENC[AES256_GCM,data:qg6lFNuI7DXMTWP5QcCsyyxO7MghWXcdtvTcUNn6VPxUFOaA/4Wt5zKRMwhZxYKdunfP4QgRaToEn968e+yemhTzmatcXUqKSWZvNKEwxr6HoGLR+OJsBIErlvVciu50o0S82zRSClxPA7RlojEJzSLIsBAOJEEMOcWjDq/b8wA=,iv:oKQcjTedhif3XUtjgyWwUGn5FdJSF5HuRqsoXYz3GN0=,tag:R3eg7Ho6lLSfxiIJv1axbA==,type:str]
+  lastmodified: "2026-08-19T18:35:52Z"
+  mac: ENC[AES256_GCM,data:w0n7Zcl3h3hAp7bVMCEaWas/MH66WurC4QugSL8ejAmJMnBC+qVc6smDkCOpaiVEUmOJ08LoylMLzdQ5OHZGS+PSV1Rpp0NVBBiWHB+skWEbXYNR4ZKNiRa5VK270jubqgJp9ga3aVbydcOFiwY5/LHU6qjcEKN8tKBffk56nH0=,iv:WZtCGZ45hlYP0Wta19xXmAi4kZG0AEGKLxoCA51cG/g=,tag:yv0KvM3QYr3ssdCQ4uRzng==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1


### PR DESCRIPTION
## Summary

- add a stable 384-bit `S3_MASTER_SECRET` to the existing SOPS-encrypted `seedyn-secret`
- enable the merged Seedyn Shottr/S3 credential derivation path
- reuse the existing HelmRelease `envFrom`; no new ingress, database, storage, or workload configuration is required

## Validation

- SOPS file remains encrypted and MAC-valid
- decrypted secret length and encoding validated without logging plaintext
- decrypted Kubernetes Secret passes strict kubeconform validation
- `git diff --check`

## Rollout

Flux will reconcile the Secret. The Seedyn image automation independently rolls out the merged application image; the generated secret is stable across pod restarts and future deployments.