### PR TITLE
Add i.gurt.ing to Seedyn

### DIFF
--- a/kubernetes/apps/default/seedyn/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seedyn/app/helmrelease.yaml
@@ -50,8 +50,9 @@ spec:
               NODE_ENV: production
               APP_URL: https://seedyn.dave.tips
               CDN_URL: https://i.dave.tips
+              MEDIA_DOMAINS: dave=https://i.dave.tips,gurt=https://i.gurt.ing
               APP_HOSTS: seedyn.dave.tips
-              MEDIA_HOSTS: i.dave.tips
+              MEDIA_HOSTS: i.dave.tips,i.gurt.ing
               REDIS_URL: redis://dragonfly.databases.svc.cluster.local:6379
               MINIO_URL: cdn.davidapps.dev
               MINIO_PORT: "443"
@@ -166,7 +167,14 @@ spec:
                 service:
                   identifier: app
                   port: http
+          - host: &alternateMediaHost i.gurt.ing
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
         tls:
           - hosts:
               - *appHost
               - *mediaHost
+              - *alternateMediaHost


### PR DESCRIPTION
## Summary
- configure the Seedyn media-domain catalog with i.dave.tips and i.gurt.ing
- allow both media hosts at the application boundary
- add i.gurt.ing to the existing external ingress and TLS host list

The existing Cloudflare wildcard tunnel and ExternalDNS gurt.ing filter already cover this hostname; no secret, certificate, or tunnel changes are needed.

## Validation
- kustomize build kubernetes/apps/default/seedyn/app
- git diff --check