### PR TITLE
fix(seedyn): run Prisma migrations before startup

### DIFF
--- a/kubernetes/apps/default/seedyn/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seedyn/app/helmrelease.yaml
@@ -40,11 +40,21 @@ spec:
             envFrom: &envFrom
               - secretRef:
                   name: seedyn-secret
+          migrate:
+            image: &image
+              repository: ghcr.io/davidilie/seedyn # {"$imagepolicy": "flux-system:seedyn:name"}
+              tag: master-8b8c4d48-1787176714 # {"$imagepolicy": "flux-system:seedyn:tag"}
+            command:
+              - node
+              - node_modules/prisma/build/index.js
+              - migrate
+              - deploy
+              - --schema
+              - prisma/schema.prisma
+            envFrom: *envFrom
         containers:
           app:
-            image:
-              repository: &image ghcr.io/davidilie/seedyn # {"$imagepolicy": "flux-system:seedyn:name"}
-              tag: &tag master-8b8c4d48-1787176714 # {"$imagepolicy": "flux-system:seedyn:tag"}
+            image: *image
             envFrom: *envFrom
             env:
               NODE_ENV: production


### PR DESCRIPTION
Add a Seedyn migration init container using the same Flux-managed immutable image as the application. It runs `prisma migrate deploy` after Postgres initialization and before the app starts, so schema changes are applied durably on every rollout.

The current `20260820003000_media_domains_key_identity` migration was also applied directly and `prisma migrate status` now reports the production schema up to date.

`kustomize build kubernetes/apps/default/seedyn/app` and `git diff --check` pass.