### PR TITLE
Add ZeroCut acquisition and creator-usage visibility

### DIFF
--- a/docs/application-observability.md
+++ b/docs/application-observability.md
@@ -61,10 +61,10 @@ Use the ZeroCut folder as the reference implementation for each instrumented pro
 
 | Dashboard | Required scope |
 | --- | --- |
-| `Overview` | Grouped business, revenue, reliability, browser, runtime, release, logs, and traces |
-| `Revenue & donations` or equivalent | Project-specific business movements and outcomes, with currencies kept separate |
+| `Overview` | Grouped business, acquisition, privacy-safe product usage, reliability, browser, runtime, release, logs, and traces |
+| `Revenue & donations` or equivalent | Durable acquisition inventory plus project-specific business movements and outcomes, with currencies kept separate |
 | `Server & rendering` | RED metrics, route and framework-phase performance, aggregate dependencies, resources, and correlated errors |
-| `Browser experience` | Web Vitals, client signal volume, frontend errors, and browser release |
+| `Browser experience` | Web Vitals, privacy-safe workspace sessions, client signal volume, frontend errors, and browser release |
 | `Runtime & deployments` | Desired/ready/updated replicas, pods, nodes, CPU, memory, restarts, image, and commit |
 | `Delivery & data` | Ingress request delivery, stable paths, Cloudflare tunnel health, and scoped database impact |
 
@@ -94,10 +94,10 @@ Grafana provisions these folders and dashboard UIDs:
 | Folder | Dashboard UID | Current scope |
 | --- | --- | --- |
 | `Apps / All Projects` | `apps-fleet` | Auto-discovered application health, resources, nodes, ingress, tunnels, databases, telemetry, logs, and business signals |
-| `Apps / ZeroCut` | `zerocut-overview` | Grouped ZeroCut overview |
-| `Apps / ZeroCut` | `zerocut-revenue` | Platform payments and supporter-to-creator donations |
+| `Apps / ZeroCut` | `zerocut-overview` | Grouped ZeroCut overview, acquisition inventory, and authenticated workspace usage |
+| `Apps / ZeroCut` | `zerocut-revenue` | Durable acquisition inventory, platform payment transitions, and supporter-to-creator donations |
 | `Apps / ZeroCut` | `zerocut-reliability` | Server, rendering, dependency, resource, log, and trace performance |
-| `Apps / ZeroCut` | `zerocut-browser` | Browser Web Vitals, client signals, errors, and release |
+| `Apps / ZeroCut` | `zerocut-browser` | Browser Web Vitals, authenticated workspace sessions, client signals, errors, and release |
 | `Apps / ZeroCut` | `zerocut-runtime` | Kubernetes placement, rollout, resources, image, and commit |
 | `Apps / ZeroCut` | `zerocut-delivery-data` | NGINX delivery, Cloudflare tunnel health, PostgreSQL impact, and ZeroCut ClickHouse health |
 | `Apps / MBRetrofit Tools` | `mbretrofit-overview` | Main and Zenzefi deployments |

--- a/docs/runbooks/project-observability-onboarding.md
+++ b/docs/runbooks/project-observability-onboarding.md
@@ -29,6 +29,8 @@ Instrument server requests, stable route templates, rendering/API phases, depend
 
 Business metrics should use bounded dimensions and integer minor-currency units. Currency, provider, mode, stream, outcome, and credit/debit direction remain separate. Observability is not the accounting ledger.
 
+Use transition metrics for activity in a selected time range and ledger-backed observable gauges for current or lifetime inventory. Do not replay historical purchases as new transition events. Product-usage panels may aggregate privacy-safe browser session IDs, but must be labeled as sessions rather than unique people or accounts.
+
 ## 4. Prove every signal before adding panels
 
 Use the read-only agent connectors to confirm metric names and labels in the live backends:

--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-browser.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-browser.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Client-side Web Vitals, signal volume, exceptions, and release correlation from the public ZeroCut telemetry gateway. Panels become populated as browsers visit the deployed release.",
+  "description": "Client-side Web Vitals, authenticated workspace session activity, exceptions, and release correlation from the public ZeroCut telemetry gateway.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -620,12 +620,204 @@
       },
       "id": 11,
       "options": {
-        "content": "No browser data is expected until a real browser loads ZeroCut with the current client instrumentation. Release comparison uses the exact 40-character deployed Git SHA.",
+        "content": "Browser and workspace panels are event-dependent. An empty selected range means no matching Faro signals were received; release comparison uses the exact 40-character deployed Git SHA.",
         "mode": "markdown"
       },
       "title": "Event-dependent dashboard",
       "transparent": true,
       "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Creator workspace usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "description": "Distinct privacy-safe Faro sessions that loaded an authenticated /app workspace page in the selected range. This is a usage proxy, not a count of unique creator accounts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 40
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" page_url:~\"https://zerocut.gg/app.*\" | stats count_uniq(session_id) as workspace_sessions",
+          "queryType": "stats",
+          "refId": "A"
+        }
+      ],
+      "title": "Workspace sessions · selected range",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "description": "Distinct authenticated-workspace Faro sessions per hour. One person may create multiple sessions, so the series deliberately describes sessions rather than creator identities.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 40
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" page_url:~\"https://zerocut.gg/app.*\" | stats by (_time:1h) count_uniq(session_id) as active_sessions",
+          "legendFormat": "workspace sessions",
+          "queryType": "statsRange",
+          "refId": "A"
+        }
+      ],
+      "title": "Workspace sessions by hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "description": "Authenticated ZeroCut workspace pages ranked by distinct Faro sessions and total browser signals. Public marketing and creator-profile traffic is excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 40
+      },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" page_url:~\"https://zerocut.gg/app.*\" | stats by (page_url) count_uniq(session_id) as sessions, count() as signals | sort by (sessions desc) | limit 20",
+          "queryType": "stats",
+          "refId": "A"
+        }
+      ],
+      "title": "Most-used workspace pages",
+      "type": "table"
     }
   ],
   "refresh": "30s",
@@ -660,6 +852,6 @@
   "timezone": "browser",
   "title": "Browser experience",
   "uid": "zerocut-browser",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-overview.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-overview.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Grouped ZeroCut overview spanning revenue, supporter-to-creator donations, server reliability, Next.js telemetry, runtime placement, browser experience, logs, traces, and the active release. Use the ZeroCut dashboards menu for focused drill-downs. Revenue is operational telemetry, not an accounting ledger.",
+  "description": "Grouped ZeroCut overview spanning durable acquisition inventory, payment transitions, authenticated workspace sessions, supporter-to-creator donations, server reliability, runtime placement, browser experience, logs, traces, and the active release. Use the ZeroCut dashboards menu for focused drill-downs.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -1213,6 +1213,242 @@
       ],
       "title": "Active release and container image",
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 102 },
+      "id": 33,
+      "panels": [],
+      "title": "Product acquisition and creator usage",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "All ZeroCut product acquisitions present in the canonical payment ledger, including acquisitions that predate telemetry. Refunded and disputed rows remain part of the lifetime inventory.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 103 },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\"}))",
+          "instant": true,
+          "legendFormat": "known acquisitions",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Known acquisitions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "Current ZeroCut acquisitions whose canonical payment-ledger state is active. This is an inventory gauge rather than a selected-range event count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 6, "x": 6, "y": 103 },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
+          "instant": true,
+          "legendFormat": "active acquisitions",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active acquisitions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "Distinct privacy-safe Faro sessions that loaded an authenticated /app workspace page in the selected range. This is a usage proxy, not a count of unique creator accounts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 6, "x": 12, "y": 103 },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" page_url:~\"https://zerocut.gg/app.*\" | stats count_uniq(session_id) as workspace_sessions",
+          "queryType": "stats",
+          "refId": "A"
+        }
+      ],
+      "title": "Workspace sessions · selected range",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+      "description": "1 means the latest periodic read of the canonical acquisition ledger succeeded; 0 means the app could not refresh it. This separates an empty ledger from a failed snapshot.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "text": "Failed" },
+                "1": { "color": "green", "text": "Healthy" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 6, "x": 18, "y": 103 },
+      "id": 37,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
+          "editorMode": "code",
+          "expr": "min({__name__=~\"zerocut_acquisition_snapshot_success(_1)?\",service_name=\"zerocut\"})",
+          "instant": true,
+          "legendFormat": "snapshot",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Acquisition snapshot",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "Distinct authenticated-workspace Faro sessions per hour. One person may create multiple sessions, so the series deliberately describes sessions rather than creator identities.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 110 },
+      "id": 38,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" page_url:~\"https://zerocut.gg/app.*\" | stats by (_time:1h) count_uniq(session_id) as active_sessions",
+          "legendFormat": "workspace sessions",
+          "queryType": "statsRange",
+          "refId": "A"
+        }
+      ],
+      "title": "Workspace sessions by hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+      "description": "Authenticated ZeroCut workspace pages ranked by distinct Faro sessions and total browser signals. Public marketing and creator-profile traffic is excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 110 },
+      "id": 39,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victoria-logs" },
+          "editorMode": "code",
+          "expr": "collector:\"alloy\" app_name:\"zerocut-web\" page_url:~\"https://zerocut.gg/app.*\" | stats by (page_url) count_uniq(session_id) as sessions, count() as signals | sort by (sessions desc) | limit 20",
+          "queryType": "stats",
+          "refId": "A"
+        }
+      ],
+      "title": "Most-used workspace pages",
+      "type": "table"
     }
   ],
   "refresh": "30s",
@@ -1224,6 +1460,6 @@
   "timezone": "browser",
   "title": "Overview",
   "uid": "zerocut-overview",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-revenue.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-revenue.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Operational revenue telemetry for ZeroCut platform payments and supporter-to-creator donations. Amounts are integer minor-currency units, currencies remain separate, and the payment ledger remains the accounting source of truth.",
+  "description": "Durable ZeroCut acquisition inventory plus operational payment-transition and supporter-to-creator donation telemetry. Amounts are integer minor-currency units, currencies remain separate, and the payment ledger remains the accounting source of truth.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -805,6 +805,285 @@
       ],
       "title": "Business events by outcome",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Durable acquisition inventory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-davidapps-cluster"
+      },
+      "description": "All ZeroCut product acquisitions present in the canonical AppPurchasePayment ledger, including purchases made before telemetry was deployed. Refunded and disputed acquisitions remain counted and are split by state in the detailed series.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 47
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-davidapps-cluster"
+          },
+          "editorMode": "code",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\"}))",
+          "instant": true,
+          "legendFormat": "known acquisitions",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Known acquisitions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-davidapps-cluster"
+      },
+      "description": "ZeroCut product acquisitions whose canonical ledger state is active. This is a current inventory gauge, not an event count constrained by the dashboard time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 47
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-davidapps-cluster"
+          },
+          "editorMode": "code",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
+          "instant": true,
+          "legendFormat": "active acquisitions",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active acquisitions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-davidapps-cluster"
+      },
+      "description": "Current active acquisition value after refunds, kept separate by product and currency. Values are integer minor-currency units and must not be added across currencies.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 12,
+        "y": 47
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-davidapps-cluster"
+          },
+          "editorMode": "code",
+          "expr": "sum by (revenue_product, commerce_currency) (max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_net_amount(_minor_currency_unit)?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
+          "instant": true,
+          "legendFormat": "{{revenue_product}} · {{commerce_currency}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active acquisition value",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-davidapps-cluster"
+      },
+      "description": "1 means the latest periodic read of the canonical acquisition ledger succeeded; 0 means the app could not refresh it. This separates an empty ledger from a broken snapshot.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Failed"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Healthy"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 47
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-davidapps-cluster"
+          },
+          "editorMode": "code",
+          "expr": "min({__name__=~\"zerocut_acquisition_snapshot_success(_1)?\",service_name=\"zerocut\"})",
+          "instant": true,
+          "legendFormat": "snapshot",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Ledger snapshot",
+      "type": "stat"
     }
   ],
   "refresh": "30s",
@@ -838,6 +1117,6 @@
   "timezone": "browser",
   "title": "Revenue & donations",
   "uid": "zerocut-revenue",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Why

The existing ZeroCut revenue panels only describe payment transitions observed inside the selected time range. They cannot show canonical acquisitions that predate the telemetry rollout. The dashboards also had no view of creators using the authenticated ZeroCut workspace, although privacy-safe Faro session data is already present in VictoriaLogs.

Companion producer: DavidIlie/zerocut#48.

## What changed

- Add durable acquisition inventory, active acquisition value, and snapshot-health panels to `Revenue & donations`.
- Add acquisition and creator-workspace usage panels to `Overview`.
- Add selected-range workspace sessions, hourly sessions, and most-used authenticated pages to `Browser experience`.
- Define usage honestly as distinct Faro sessions on `/app` pages, not unique creator accounts.
- Document the difference between selected-range transition metrics, ledger-backed inventory gauges, and session-based usage.

No payment, user, or creator identifiers are queried or displayed. Currencies remain separate, and `max by (...)` prevents identical snapshots from multiple app replicas being added together.

## Live evidence

Over the latest seven-day production window, the exact dashboard LogsQL returned 14 authenticated workspace sessions. `/app/dashboard` was the highest-volume workspace surface. All three LogsQL expressions returned live data.

Validation:

- `jq empty` for all changed dashboard JSON
- unique panel IDs for every changed dashboard
- `kubectl kustomize kubernetes/apps/observability/grafana/app`
- all four new PromQL expressions parse successfully against DavidApps Prometheus
- exact stat, hourly, and page-breakdown LogsQL queries execute successfully against VictoriaLogs
- `git diff --check`

## Rollout

Merge and deploy DavidIlie/zerocut#48 first. The session panels can populate immediately; acquisition panels populate after the app emits its first cached ledger snapshot. No Grafana datasource, Alloy, or DavidApps cluster change is required.
