### PR TITLE
feat(default): deploy Bostan Discord bot

### DIFF
--- a/kubernetes/apps/default/bostan-discord-bot/app/claim.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/app/claim.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bostan-discord-bot
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: openebs-hostpath

--- a/kubernetes/apps/default/bostan-discord-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/app/helmrelease.yaml
@@ -1,0 +1,122 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bernd-schorgers/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bostan-discord-bot
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      bostan-discord-bot:
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          terminationGracePeriodSeconds: 30
+        containers:
+          app:
+            image:
+              repository: ghcr.io/bostanenterprise/bostan-discord-bot # {"$imagepolicy": "flux-system:bostan-discord-bot:name"}
+              tag: main-36dace71-1787421096 # {"$imagepolicy": "flux-system:bostan-discord-bot:tag"}
+            env:
+              NODE_ENV: production
+              TZ: Europe/Bucharest
+              DISCORD_GUILD_ID: "1540757211146493993"
+              DISCORD_ADMIN_USER_IDS: "243009043260637184,968951950446063676"
+              DISCORD_BOT_TOKEN_FILE: /run/secrets/bostan/discord-bot-token
+              INTERACTION_SIGNING_SECRET_FILE: /run/secrets/bostan/interaction-signing-secret
+              GITHUB_POLL_INTERVAL_SECONDS: "60"
+              DATA_DIR: /data
+              HEALTH_PORT: "8080"
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /livez
+                    port: &port 8080
+                  periodSeconds: 2
+                  timeoutSeconds: 2
+                  failureThreshold: 45
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /livez
+                    port: *port
+                  periodSeconds: 15
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  periodSeconds: 5
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 20m
+                memory: 128Mi
+              limits:
+                cpu: 1000m
+                memory: 512Mi
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: docker-regcred
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    persistence:
+      data:
+        existingClaim: bostan-discord-bot
+        globalMounts:
+          - path: /data
+      secrets:
+        type: secret
+        name: bostan-discord-bot-secret
+        defaultMode: 0440
+        globalMounts:
+          - path: /run/secrets/bostan
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        controller: *app
+        ports:
+          health:
+            port: *port

--- a/kubernetes/apps/default/bostan-discord-bot/app/kustomization.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./claim.yaml
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/bostan-discord-bot/app/secret.sops.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  discord-bot-token: ENC[AES256_GCM,data:J01HubRYNQnak3KrOqH2sWgw3iSTLLSrYbXiK5YRo2GZGxUHK3GU9IIZQBxqc19GpydHj7oejPCkPB93NZcnsTr6KJpxCWXCySGiFaZfjDO745A/YXgNTOzA6mYT3s6T,iv:q8wWd84XNBJb8x8snyCrLGZ03ktaF7Dr7sJs4nkwnKM=,tag:JfDrHSQ2a89unF580nNowA==,type:str]
+  interaction-signing-secret: ENC[AES256_GCM,data:3FIu2cVFdQ7Z/ywMgEpuqF/FZnRjZTOywaqQOPFLV0RRI29aAjhS1QeWoSTYjOGiH2bvX0vj0RpQ5oEfOj2ENO74Ay/FeUVbio+LHT20yw4fo+HWGvu3WQ==,iv:FEKU4I9QdOrpuyR7LOnqWd2/Xq2x8eed3TSZNj3pgFo=,tag:rjA7UR91wsVSEDHNByMgfg==,type:str]
+kind: Secret
+metadata:
+  name: bostan-discord-bot-secret
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvNHNFaUJwQjByZGRuYWJt
+        NWFMVWZjNStia2U2bjk5S2MwcUdMT3hLcVZVCkZOaVNqMlZFUHpldVJONURFL1FX
+        NWNTeXhwTkJiVnNHcWJDVjZocVlqaGcKLS0tIHh6TUpGYkFFZ3Vxa0tuZEo5b0No
+        cGJwZXRSaVpJRlNmdVgxaUxRUEpzeTQK6HJVDjXLac05XjGyQj09zdKVaXUt+1Lu
+        kBA/MbMVl3a8f0+gBu8O7TVl5Mh5b1JgWY7OVP1o4sJOv8mrEH22JQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-22T17:42:26Z"
+  mac: ENC[AES256_GCM,data:tdlB6yM0IhD138qEJYPVnaec9nLAAVAY+luIUZhHyBo+zXEeR4gAT/1nBI6sx9EDC1uD31LLq7mWAdohbpzH/ESsaxUfsiOzMoBWsTnFbmixQnLlpnjOwv2aL7CUVSHN70E96ZPK+5WTILfJh5dGKdBaq8w4WFqzS95uT5d0A80=,iv:lkupIMqkKggW2dNUhTE3jnrixILK1HWOLx+wqBTs3is=,tag:HNmcgHAPMDWJfWnq5FZBtA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/default/bostan-discord-bot/ks.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bostan-discord-bot
+  namespace: &namespace default
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: openebs
+      namespace: openebs-system
+  path: ./kubernetes/apps/default/bostan-discord-bot/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/image-automations/app/bostan-discord-bot.yaml
+++ b/kubernetes/apps/default/image-automations/app/bostan-discord-bot.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: bostan-discord-bot
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: bostan-discord-bot
+  filterTags:
+    pattern: "^main-[a-f0-9]+-(?P<ts>[0-9]+)"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: bostan-discord-bot
+  namespace: flux-system
+spec:
+  image: ghcr.io/bostanenterprise/bostan-discord-bot
+  interval: 1m0s
+  secretRef:
+    name: docker-regcred

--- a/kubernetes/apps/default/image-automations/app/kustomization.yaml
+++ b/kubernetes/apps/default/image-automations/app/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./bostan-discord-bot.yaml
   - ./error-pages.yaml
   - ./personal-dashboard.yaml
   - ./seedyn.yaml

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./homepage/ks.yaml
   - ./it-tools/ks.yaml
   - ./cliproxy/ks.yaml
+  - ./bostan-discord-bot/ks.yaml
   - ./paperless/ks.yaml
   - ./stirling-pdf/ks.yaml
   # - ./n8n/ks.yaml


### PR DESCRIPTION
Deploys the private Bostan Discord bot image as one non-root Recreate replica with an RWO OpenEBS data claim, SOPS-encrypted Discord credentials, gateway-aware health probes, private GHCR pulls, and Flux image automation.\n\nValidated with kustomize builds, encrypted-secret scan, and the targeted Flux-local HelmRelease test.