### PR TITLE
feat(bostan-discord-bot): enable private GitHub feeds

### DIFF
--- a/kubernetes/apps/default/bostan-discord-bot/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/app/helmrelease.yaml
@@ -42,6 +42,7 @@ spec:
               DISCORD_ADMIN_USER_IDS: "243009043260637184,968951950446063676"
               DISCORD_BOT_TOKEN_FILE: /run/secrets/bostan/discord-bot-token
               INTERACTION_SIGNING_SECRET_FILE: /run/secrets/bostan/interaction-signing-secret
+              GITHUB_TOKEN_FILE: /run/secrets/bostan/github-token
               GITHUB_POLL_INTERVAL_SECONDS: "60"
               DATA_DIR: /data
               HEALTH_PORT: "8080"

--- a/kubernetes/apps/default/bostan-discord-bot/app/secret.sops.yaml
+++ b/kubernetes/apps/default/bostan-discord-bot/app/secret.sops.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  discord-bot-token: ENC[AES256_GCM,data:J01HubRYNQnak3KrOqH2sWgw3iSTLLSrYbXiK5YRo2GZGxUHK3GU9IIZQBxqc19GpydHj7oejPCkPB93NZcnsTr6KJpxCWXCySGiFaZfjDO745A/YXgNTOzA6mYT3s6T,iv:q8wWd84XNBJb8x8snyCrLGZ03ktaF7Dr7sJs4nkwnKM=,tag:JfDrHSQ2a89unF580nNowA==,type:str]
-  interaction-signing-secret: ENC[AES256_GCM,data:3FIu2cVFdQ7Z/ywMgEpuqF/FZnRjZTOywaqQOPFLV0RRI29aAjhS1QeWoSTYjOGiH2bvX0vj0RpQ5oEfOj2ENO74Ay/FeUVbio+LHT20yw4fo+HWGvu3WQ==,iv:FEKU4I9QdOrpuyR7LOnqWd2/Xq2x8eed3TSZNj3pgFo=,tag:rjA7UR91wsVSEDHNByMgfg==,type:str]
+  discord-bot-token: ENC[AES256_GCM,data:jzSj40alu6Sc6cbZ9FdrXAiGy27i+n6SNEaY24a0lChD5TeGIo7r7f0/VwTb+t2qJAUKjajt4MuhH+KdwAPxpEZ7W+Unl2GZBu/tg2a8EfyeIa7KPJjmRUOQ5f8igXht,iv:pWnLQwHGrLp3vDDCC9hzFqu+Wg9hTiew5zoarpjG6x8=,tag:oqbMWMKok0N/aEq6MHKlPQ==,type:str]
+  github-token: ENC[AES256_GCM,data:UNYqBchG+N2AuWmmxSroKzvPd4YQOlQXaDAex/Kuc6WFMGfrz7GN86/lRfmrFE7YOrRIGYhg2oWQtB1h0oIZlhsj/HMImoDrQPjbIIgB3ixE4sff1ddLo7mYaSaMAI9d+3sKgwqgJIHIDEhYUHB4QxmvFPUlXphUvSAhGQ==,iv:RGcy+6NlhgHugJYWFY4/zfMXazzNj50q4ACA+qLsy+c=,tag:1N/AXFXvtkkEoHTkCUypWA==,type:str]
+  interaction-signing-secret: ENC[AES256_GCM,data:DXr8oWPEH1SEunhMPwZX3j6IwqnPRvMSnd7lcvNq/TlwGgqx6gQFGP/fGTcRGJEzvG+cwjWiX4KcQCBfPZ6waZG3BUEdUymeazzZw8EMAFB18TcW4dwX+w==,iv:i4OBoIMZSrOSH/PDAcAo9wHf1LzHgG7qX5pGuSWa0HQ=,tag:UL1ubARQ6Zcl6coI0g2Xvg==,type:str]
 kind: Secret
 metadata:
   name: bostan-discord-bot-secret
@@ -10,14 +11,14 @@ sops:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvNHNFaUJwQjByZGRuYWJt
-        NWFMVWZjNStia2U2bjk5S2MwcUdMT3hLcVZVCkZOaVNqMlZFUHpldVJONURFL1FX
-        NWNTeXhwTkJiVnNHcWJDVjZocVlqaGcKLS0tIHh6TUpGYkFFZ3Vxa0tuZEo5b0No
-        cGJwZXRSaVpJRlNmdVgxaUxRUEpzeTQK6HJVDjXLac05XjGyQj09zdKVaXUt+1Lu
-        kBA/MbMVl3a8f0+gBu8O7TVl5Mh5b1JgWY7OVP1o4sJOv8mrEH22JQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRbFI5ZTBnWE9yYUphUTBQ
+        VDErVDEwQkFWNnhMb1FKcGZiNFRVSllnaWdzCitScm9RZzhYVUxTR1J1aUJtdVFX
+        eFd6NEJwTFhmV2M0VDY5N2Z5V0p3OVUKLS0tIEVFcnpTZVZCZHV0VnZlMm9admN2
+        Z0I2T2V0ek1aUFVON1hDZm1mWWdpNDQKS+TzJETNdsPoGKtOXZPtQJ6cUxitJajU
+        CaPT4vMbc8V/DGwECow8lHtnNqSFtHuFThzwM5trF1J8ta2dCu1e4A==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-22T17:42:26Z"
-  mac: ENC[AES256_GCM,data:tdlB6yM0IhD138qEJYPVnaec9nLAAVAY+luIUZhHyBo+zXEeR4gAT/1nBI6sx9EDC1uD31LLq7mWAdohbpzH/ESsaxUfsiOzMoBWsTnFbmixQnLlpnjOwv2aL7CUVSHN70E96ZPK+5WTILfJh5dGKdBaq8w4WFqzS95uT5d0A80=,iv:lkupIMqkKggW2dNUhTE3jnrixILK1HWOLx+wqBTs3is=,tag:HNmcgHAPMDWJfWnq5FZBtA==,type:str]
+  lastmodified: "2026-08-22T19:23:50Z"
+  mac: ENC[AES256_GCM,data:XOTsaEjGmHVsHPf00JyyN04msEMbCwg+dYXO8QNWkSkaEk4tn2Jn6iPSg5ZrbVkZ5buf613cb1QF6PDQYceCeV5dRiBpDOLD3u6IUo+EL6KbdyonX06z9t8fjZiYA5VEmKWLGpSYnZ33gy2utaBdTiD4NXlN69XfdkdTp0CBsiw=,iv:HjcgTghwA1AoUqB0GXzZZOKTxEnI/PQECi+2fVr7uEM=,tag:mtOStIbD0hg2aEkaDLMcKw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1


### PR DESCRIPTION
Adds the repository-scoped GitHub token to the SOPS-encrypted bot secret and mounts it through GITHUB_TOKEN_FILE. The token is read-only and limited to BostanEnterprise/swish and BostanEnterprise/libertos.\n\nValidation:\n- kubectl kustomize app\n- targeted flux-local Helm test