### PR TITLE
Stage isolated GitOps boundary for friends code runner

### DIFF
--- a/hack/validate-hermes-friends-code
+++ b/hack/validate-hermes-friends-code
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+app_root="${repo_root}/kubernetes/apps/hermes-friends-code"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+
+resolve() {
+  if command -v "$1" >/dev/null 2>&1; then
+    command -v "$1"
+    return
+  fi
+  if command -v mise >/dev/null 2>&1; then
+    mise which "$1" 2>/dev/null && return
+  fi
+  echo "missing required command: $1" >&2
+  exit 1
+}
+
+kustomize_bin="${KUSTOMIZE_BIN:-$(resolve kustomize)}"
+yq_bin="${YQ_BIN:-$(resolve yq)}"
+
+"${kustomize_bin}" build "${app_root}" >"${scratch}/root.yaml"
+"${kustomize_bin}" build "${app_root}/runner/boundary/app" >"${scratch}/boundary.yaml"
+"${kustomize_bin}" build "${app_root}/runner/runtime-validation/app" >"${scratch}/runtime.yaml"
+"${kustomize_bin}" build "${app_root}/runner/app" >"${scratch}/workloads.yaml"
+
+if grep -Fxq '  - ./hermes-friends-code' "${repo_root}/kubernetes/apps/kustomization.yaml"; then
+  echo "friends runner unexpectedly referenced by the live apps root" >&2
+  exit 1
+fi
+
+child_count="$("${yq_bin}" ea '[.] | map(select(.kind == "Kustomization" and .apiVersion == "kustomize.toolkit.fluxcd.io/v1")) | length' "${scratch}/root.yaml")"
+suspended_count="$("${yq_bin}" ea '[.] | map(select(.kind == "Kustomization" and .apiVersion == "kustomize.toolkit.fluxcd.io/v1" and .spec.suspend == true)) | length' "${scratch}/root.yaml")"
+if [[ "${child_count}" != "3" || "${suspended_count}" != "3" ]]; then
+  echo "expected three suspended Flux children, got ${suspended_count}/${child_count}" >&2
+  exit 1
+fi
+
+deployment_count="$("${yq_bin}" ea '[.] | map(select(.kind == "Deployment")) | length' "${scratch}/workloads.yaml")"
+zero_deployment_count="$("${yq_bin}" ea '[.] | map(select(.kind == "Deployment" and .spec.replicas == 0)) | length' "${scratch}/workloads.yaml")"
+if [[ "${deployment_count}" != "4" || "${zero_deployment_count}" != "4" ]]; then
+  echo "expected four zero-replica Deployments, got ${zero_deployment_count}/${deployment_count}" >&2
+  exit 1
+fi
+
+for manifest in "${scratch}"/*.yaml; do
+  forbidden="$("${yq_bin}" ea '[.] | map(select(.kind == "Secret" or .kind == "Ingress" or .kind == "HTTPRoute")) | length' "${manifest}")"
+  if [[ "${forbidden}" != "0" ]]; then
+    echo "forbidden live surface or Secret in ${manifest}" >&2
+    exit 1
+  fi
+done
+
+generator_image="$("${yq_bin}" ea '[.] | map(select(.kind == "ConfigMap" and .metadata.name == "hermes-friend-runner-policy"))[0].data.generator-image' "${scratch}/workloads.yaml")"
+tester_image="$("${yq_bin}" ea '[.] | map(select(.kind == "ConfigMap" and .metadata.name == "hermes-friend-runner-policy"))[0].data.tester-image' "${scratch}/workloads.yaml")"
+if [[ "${generator_image}" != ghcr.io/davidilie/hermes-friend-generator@sha256:0000000000000000000000000000000000000000000000000000000000000000 ||
+      "${tester_image}" != ghcr.io/davidilie/hermes-friend-tester@sha256:0000000000000000000000000000000000000000000000000000000000000000 ||
+      "${generator_image}" == "${tester_image}" ]]; then
+  echo "generator and tester must remain distinct inert image contracts" >&2
+  exit 1
+fi
+
+runtime_class="$("${yq_bin}" 'select(.kind == "Job").spec.template.spec.runtimeClassName' "${scratch}/runtime.yaml")"
+runtime_revision="$("${yq_bin}" 'select(.kind == "Job").metadata.labels."hermes.davidapps.dev/activation-revision"' "${scratch}/runtime.yaml")"
+runtime_image="$("${yq_bin}" 'select(.kind == "Job").spec.template.spec.containers[0].image' "${scratch}/runtime.yaml")"
+if [[ "${runtime_class}" != "kata-qemu" || "${runtime_revision}" != "UNSET" ||
+      "${runtime_image}" != ghcr.io/davidilie/hermes-friend-runtime-validator@sha256:0000000000000000000000000000000000000000000000000000000000000000 ]]; then
+  echo "staged Kata validation contract is not inert and exact" >&2
+  exit 1
+fi
+
+policy_count="$("${yq_bin}" ea '[.] | map(select(.kind == "ValidatingAdmissionPolicy")) | length' "${scratch}/boundary.yaml")"
+binding_count="$("${yq_bin}" ea '[.] | map(select(.kind == "ValidatingAdmissionPolicyBinding")) | length' "${scratch}/boundary.yaml")"
+if [[ "${policy_count}" != "3" || "${binding_count}" != "3" ]]; then
+  echo "expected three admission policies and bindings" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--activation-preflight" ]]; then
+  kubeconfig="${2:-}"
+  if [[ -z "${kubeconfig}" || ! -f "${kubeconfig}" ]]; then
+    echo "usage: $0 --activation-preflight /path/to/kubeconfig" >&2
+    exit 1
+  fi
+  kubectl_bin="${KUBECTL_BIN:-$(resolve kubectl)}"
+  "${kubectl_bin}" --kubeconfig "${kubeconfig}" get runtimeclass kata-qemu >/dev/null
+  echo "Kata RuntimeClass exists; run the pinned validation child before workloads"
+fi
+
+echo "Hermes friends code staging invariants passed"

--- a/kubernetes/apps/hermes-friends-code/README.md
+++ b/kubernetes/apps/hermes-friends-code/README.md
@@ -1,0 +1,112 @@
+# Hermes friends public-code runner
+
+This tree is intentionally inert and is **not referenced** by
+`kubernetes/apps/kustomization.yaml`. Merging it creates no Namespace, Flux
+Kustomization, PVC, Pod, broker rollout, or other live cluster object. The
+three child Flux Kustomizations are also suspended and every long-running
+Deployment has zero replicas. A separate activation pull request must first
+add the root reference, then advance the three children in order.
+
+The namespaces split authority as follows:
+
+- `hermes-friends-control`: dispatcher and its narrow Job-creation identity;
+- `hermes-friends-sandbox`: disposable generator and tester Jobs, with no
+  Secrets, PVCs, GitHub access, or reusable Kubernetes token;
+- `hermes-friends-runtime`: one tokenless, networkless Kata validation Job;
+- `hermes-friends-artifact`: the only persistent artifact store;
+- `hermes-friends-creator`: the repository-creation GitHub App only;
+- `hermes-friends-publisher`: the content-and-draft-PR GitHub App only.
+
+No owner/private GitHub credential, Workspace identity, SOPS key, Fleet token,
+media token, observability credential, host mount, or owner Hermes PVC belongs
+in any of these namespaces. Secret names and required keys are contracts only;
+the public repository never contains plaintext or invented credential values.
+
+The later encrypted provisioning change must create exactly these independent
+Secrets in their stated namespaces:
+
+| Namespace | Secret | Required key | Consumer |
+| --- | --- | --- | --- |
+| `default` | future broker runner contract | runner token SHA-256 and approval private key | Broker dispatch signing only |
+| `hermes-friends-control` | `hermes-friend-dispatcher-auth` | `runner-token` | Broker runner API only |
+| `hermes-friends-control` | `hermes-friend-trust` | `approval-public-key` | Approval verification |
+| `hermes-friends-artifact` | `hermes-friend-trust` | `approval-public-key` | Approval verification |
+| `hermes-friends-artifact` | `hermes-friend-artifact-signer` | `collector-private-key` | Artifact receipts only |
+| `hermes-friends-creator` | `hermes-friend-trust` | `approval-public-key` | Approval verification |
+| `hermes-friends-creator` | `hermes-friend-creator-github-app` | `private-key.pem` | Empty sandbox organization creation App |
+| `hermes-friends-publisher` | `hermes-friend-trust` | `approval-public-key` | Approval verification |
+| `hermes-friends-publisher` | `hermes-friend-publisher-github-app` | `private-key.pem` | Exact-repository publisher App |
+
+The creator and publisher keys must be different GitHub Apps. Neither may be
+installed on David's personal account or any organization that contains a
+private repository. Generator and tester Jobs cannot reference any Secret;
+the admission policy rejects such a Job before it is created.
+
+The dispatcher receives Kubernetes authority through an explicitly projected,
+one-hour ServiceAccount token that the client rereads for every API call. The
+token omits an invented audience so the kubelet uses the API server's configured
+audience. `automountServiceAccountToken`
+stays false for every Pod. The dispatcher may create/get only the bounded
+request ConfigMaps and create/observe Jobs in `hermes-friends-sandbox`; it may
+not read Secrets, logs, exec, update Job specs, delete resources, or access any
+other namespace. It creates the Job first, reads back and verifies its UID, then
+creates the immutable input ConfigMap with that Job as its controller owner.
+Crashing before the ConfigMap exists leaves only a deadline-bounded Job;
+crashing after it exists leaves a garbage-collectable dependent. The Job TTL
+controller removes the Job and garbage collection removes its input ConfigMap.
+
+Prometheus reaches each daemon through a Cilium L7 rule that permits only
+`GET /metrics`. Monitoring therefore cannot call the creator, publisher, or
+artifact write APIs merely because those roles expose metrics on the same
+listener.
+
+The existing broker's runner API remains disabled by its fail-closed source
+default. This pull request does not modify its HelmRelease or NetworkPolicy, so
+merge cannot restart or widen the live broker. The default-namespace row above
+is only a contract because the final broker secret names and file environment
+variables must come from the reviewed runner API implementation. No placeholder
+Secret is safe to commit for it.
+
+Activation must be a later pull request and proceeds in this exact order:
+
+1. Install and independently accept `RuntimeClass/kata-qemu` on the selected
+   sandbox nodes. The class is absent from the live cluster as of staging.
+2. Pin the dedicated runtime validator to a reviewed non-inert digest and set
+   the same non-`UNSET` activation revision on the Job and Pod template.
+3. Pin distinct generator and tester repositories and digests, every control
+   image digest, the model relay, test catalog, policy revision, organization,
+   and independent GitHub App identities. Provision only the encrypted secret
+   contracts below. Prove the sandbox organization contains no private
+   repositories or Actions secrets.
+4. Add this directory to `kubernetes/apps/kustomization.yaml`. Keep all three
+   children suspended. Merge and prove only the namespaces and suspended Flux
+   objects appeared.
+5. Unsuspend `hermes-friends-code-boundary` alone. Prove default-deny,
+   DNS-restricted egress, quotas, RBAC, and all three admission policies are
+   Ready.
+6. Unsuspend `hermes-friends-code-runtime-validation` alone. It cannot become
+   Ready unless a Pod starts under `kata-qemu` and the one-shot validator exits
+   successfully. The workload child depends on this Ready condition.
+7. Use a fresh David approval bound to the final policy hash. Old approvals
+   must never be grandfathered. Only then change required replicas and
+   unsuspend `hermes-friends-code`.
+8. In a separate reviewed broker change, add the exact runner API contract,
+   network ingress, and secrets, then enable execution. This staged pull
+   request deliberately does not touch the live broker.
+
+The admission policy pins `runtimeClassName: kata-qemu`, distinct generator and
+tester images, exact commands, tokenless identity, bounded resources and
+volumes, `ndots: 1`, and automatic Job TTL. Dispatcher RBAC permits only
+create/get on sandbox Jobs and ConfigMaps plus get on the named `kata-qemu`
+RuntimeClass. The workload child cannot race ahead of either the deny boundary
+or runtime proof because its Flux dependency is fail-closed.
+
+Broad DNS egress is forbidden. Cilium DNS rules allow only the exact internal
+service names each component needs and `api.github.com` for the creator and
+publisher. `ndots: 1` prevents resolver search-suffix probes from becoming an
+accidental alternate DNS channel. The generator network policy reserves one
+path to a future
+`hermes-friend-model-relay` on port 8084. No relay workload or provider secret
+is included here because no reviewed public-only model relay image/account
+exists yet. Consequently generation remains impossible even if someone were
+to remove only one of the other safety latches.

--- a/kubernetes/apps/hermes-friends-code/kustomization.yaml
+++ b/kubernetes/apps/hermes-friends-code/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespaces.yaml
+  - ./runner/ks.yaml

--- a/kubernetes/apps/hermes-friends-code/namespaces.yaml
+++ b/kubernetes/apps/hermes-friends-code/namespaces.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-friends-control
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-friends-sandbox
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-friends-runtime
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-friends-artifact
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-friends-creator
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-friends-publisher
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/kubernetes/apps/hermes-friends-code/runner/app/configmap.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/configmap.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-friend-runner-policy
+  namespace: hermes-friends-control
+data:
+  # A later reviewed activation replaces the complete signed policy together
+  # with every real digest. Inertness is enforced by root omission, suspended
+  # Flux children, zero replicas, and impossible image digests.
+  policy-revision: disabled
+  github-api-url: https://api.github.com
+  sandbox-namespace: hermes-friends-sandbox
+  test-catalog-configmap: UNSET
+  sandbox-organization: UNSET
+  creator-app-id: UNSET
+  creator-installation-id: UNSET
+  publisher-app-id: UNSET
+  publisher-installation-id: UNSET
+  generator-image: ghcr.io/davidilie/hermes-friend-generator@sha256:0000000000000000000000000000000000000000000000000000000000000000
+  tester-image: ghcr.io/davidilie/hermes-friend-tester@sha256:0000000000000000000000000000000000000000000000000000000000000000
+  dispatcher-image: &inert-control-image ghcr.io/davidilie/hermes-friend-runner@sha256:0000000000000000000000000000000000000000000000000000000000000000
+  artifactd-image: *inert-control-image
+  creator-image: *inert-control-image
+  publisher-image: *inert-control-image
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-friend-creator-policy
+  namespace: hermes-friends-creator
+data:
+  sandbox-organization: UNSET
+  app-id: UNSET
+  installation-id: UNSET
+  github-api-url: https://api.github.com
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-friend-publisher-policy
+  namespace: hermes-friends-publisher
+data:
+  sandbox-organization: UNSET
+  app-id: UNSET
+  installation-id: UNSET
+  github-api-url: https://api.github.com

--- a/kubernetes/apps/hermes-friends-code/runner/app/deployments.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/deployments.yaml
@@ -1,0 +1,542 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-friend-dispatcher
+  namespace: hermes-friends-control
+spec:
+  replicas: 0
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: &dispatcher-labels
+      app.kubernetes.io/name: hermes-friend-dispatcher
+  template:
+    metadata:
+      labels: *dispatcher-labels
+    spec:
+      serviceAccountName: hermes-friend-dispatcher
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dispatcher
+          image: ghcr.io/davidilie/hermes-friend-runner@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          command: [/hermes-friend-runner]
+          args: [dispatcher]
+          env:
+            - name: HERMES_FRIEND_BROKER_URL
+              value: http://hermes-friend-broker.default.svc.cluster.local:8080
+            - name: HERMES_FRIEND_BROKER_RUNNER_TOKEN_FILE
+              value: /run/secrets/broker/runner-token
+            - name: HERMES_FRIEND_APPROVAL_PUBLIC_KEY_FILE
+              value: /run/secrets/trust/approval-public-key
+            - name: HERMES_FRIEND_ARTIFACT_URL
+              value: http://hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local:8081
+            - name: HERMES_FRIEND_CREATOR_URL
+              value: http://hermes-friend-creator.hermes-friends-creator.svc.cluster.local:8082
+            - name: HERMES_FRIEND_PUBLISHER_URL
+              value: http://hermes-friend-publisher.hermes-friends-publisher.svc.cluster.local:8083
+            - name: HERMES_FRIEND_SANDBOX_NAMESPACE
+              value: hermes-friends-sandbox
+            - name: HERMES_FRIEND_SANDBOX_SERVICE_ACCOUNT
+              value: hermes-friend-sandbox
+            - name: HERMES_FRIEND_SANDBOX_RUNTIME_CLASS
+              value: kata-qemu
+            - name: HERMES_FRIEND_GENERATOR_IMAGE_REPOSITORY
+              value: ghcr.io/davidilie/hermes-friend-generator
+            - name: HERMES_FRIEND_TEST_IMAGE_REPOSITORY
+              value: ghcr.io/davidilie/hermes-friend-tester
+            - name: HERMES_FRIEND_RUNNER_JOURNAL
+              value: /var/lib/hermes-friend-runner/journal.db
+            - name: HERMES_FRIEND_MODEL_RELAY_URL
+              value: http://hermes-friend-model-relay.hermes-friends-control.svc.cluster.local:8084
+            - name: HERMES_FRIEND_TEST_CATALOG_CONFIGMAP
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-runner-policy
+                  key: test-catalog-configmap
+            - name: HERMES_FRIEND_KUBERNETES_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: HERMES_FRIEND_KUBERNETES_CA_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - name: HERMES_FRIEND_LISTEN_ADDRESS
+              value: :8080
+          ports:
+            - name: http
+              containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: journal
+              mountPath: /var/lib/hermes-friend-runner
+            - name: broker-auth
+              mountPath: /run/secrets/broker
+              readOnly: true
+            - name: trust
+              mountPath: /run/secrets/trust
+              readOnly: true
+            - name: kube-api-access
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: journal
+          persistentVolumeClaim:
+            claimName: hermes-friend-dispatcher-journal
+        - name: broker-auth
+          secret:
+            secretName: hermes-friend-dispatcher-auth
+            defaultMode: 0440
+            items:
+              - key: runner-token
+                path: runner-token
+        - name: trust
+          secret:
+            secretName: hermes-friend-trust
+            defaultMode: 0440
+            items:
+              - key: approval-public-key
+                path: approval-public-key
+        - name: kube-api-access
+          projected:
+            defaultMode: 0440
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3600
+                  path: token
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-friend-artifactd
+  namespace: hermes-friends-artifact
+spec:
+  replicas: 0
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: &artifact-labels
+      app.kubernetes.io/name: hermes-friend-artifactd
+  template:
+    metadata:
+      labels: *artifact-labels
+    spec:
+      serviceAccountName: hermes-friend-artifactd
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: artifactd
+          image: ghcr.io/davidilie/hermes-friend-runner@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          command: [/hermes-friend-runner]
+          args: [artifactd]
+          env:
+            - name: HERMES_FRIEND_APPROVAL_PUBLIC_KEY_FILE
+              value: /run/secrets/trust/approval-public-key
+            - name: HERMES_FRIEND_COLLECTOR_PRIVATE_KEY_FILE
+              value: /run/secrets/signer/collector-private-key
+            - name: HERMES_FRIEND_ARTIFACT_DIRECTORY
+              value: /var/lib/hermes-friend-artifacts
+            - name: HERMES_FRIEND_LISTEN_ADDRESS
+              value: :8081
+          ports:
+            - name: http
+              containerPort: 8081
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: artifacts
+              mountPath: /var/lib/hermes-friend-artifacts
+            - name: trust
+              mountPath: /run/secrets/trust
+              readOnly: true
+            - name: signer
+              mountPath: /run/secrets/signer
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: artifacts
+          persistentVolumeClaim:
+            claimName: hermes-friend-artifacts
+        - name: trust
+          secret:
+            secretName: hermes-friend-trust
+            defaultMode: 0440
+            items:
+              - key: approval-public-key
+                path: approval-public-key
+        - name: signer
+          secret:
+            secretName: hermes-friend-artifact-signer
+            defaultMode: 0440
+            items:
+              - key: collector-private-key
+                path: collector-private-key
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-friend-creator
+  namespace: hermes-friends-creator
+spec:
+  replicas: 0
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: &creator-labels
+      app.kubernetes.io/name: hermes-friend-creator
+  template:
+    metadata:
+      labels: *creator-labels
+    spec:
+      serviceAccountName: hermes-friend-creator
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: creator
+          image: ghcr.io/davidilie/hermes-friend-runner@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          command: [/hermes-friend-runner]
+          args: [creator]
+          env:
+            - name: HERMES_FRIEND_CREATOR_APP_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-creator-policy
+                  key: app-id
+            - name: HERMES_FRIEND_CREATOR_INSTALLATION_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-creator-policy
+                  key: installation-id
+            - name: HERMES_FRIEND_SANDBOX_ORG
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-creator-policy
+                  key: sandbox-organization
+            - name: HERMES_FRIEND_GITHUB_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-creator-policy
+                  key: github-api-url
+            - name: HERMES_FRIEND_CREATOR_APP_PRIVATE_KEY_FILE
+              value: /run/secrets/github-app/private-key.pem
+            - name: HERMES_FRIEND_APPROVAL_PUBLIC_KEY_FILE
+              value: /run/secrets/trust/approval-public-key
+            - name: HERMES_FRIEND_LISTEN_ADDRESS
+              value: :8082
+          ports:
+            - name: http
+              containerPort: 8082
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+              ephemeral-storage: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: github-app
+              mountPath: /run/secrets/github-app
+              readOnly: true
+            - name: trust
+              mountPath: /run/secrets/trust
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: github-app
+          secret:
+            secretName: hermes-friend-creator-github-app
+            defaultMode: 0440
+            items:
+              - key: private-key.pem
+                path: private-key.pem
+        - name: trust
+          secret:
+            secretName: hermes-friend-trust
+            defaultMode: 0440
+            items:
+              - key: approval-public-key
+                path: approval-public-key
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-friend-publisher
+  namespace: hermes-friends-publisher
+spec:
+  replicas: 0
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: &publisher-labels
+      app.kubernetes.io/name: hermes-friend-publisher
+  template:
+    metadata:
+      labels: *publisher-labels
+    spec:
+      serviceAccountName: hermes-friend-publisher
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: publisher
+          image: ghcr.io/davidilie/hermes-friend-runner@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          command: [/hermes-friend-runner]
+          args: [publisher]
+          env:
+            - name: HERMES_FRIEND_PUBLISHER_APP_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-publisher-policy
+                  key: app-id
+            - name: HERMES_FRIEND_PUBLISHER_INSTALLATION_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-publisher-policy
+                  key: installation-id
+            - name: HERMES_FRIEND_SANDBOX_ORG
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-publisher-policy
+                  key: sandbox-organization
+            - name: HERMES_FRIEND_GITHUB_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: hermes-friend-publisher-policy
+                  key: github-api-url
+            - name: HERMES_FRIEND_ARTIFACT_URL
+              value: http://hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local:8081
+            - name: HERMES_FRIEND_PUBLISHER_APP_PRIVATE_KEY_FILE
+              value: /run/secrets/github-app/private-key.pem
+            - name: HERMES_FRIEND_APPROVAL_PUBLIC_KEY_FILE
+              value: /run/secrets/trust/approval-public-key
+            - name: HERMES_FRIEND_LISTEN_ADDRESS
+              value: :8083
+          ports:
+            - name: http
+              containerPort: 8083
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: github-app
+              mountPath: /run/secrets/github-app
+              readOnly: true
+            - name: trust
+              mountPath: /run/secrets/trust
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: github-app
+          secret:
+            secretName: hermes-friend-publisher-github-app
+            defaultMode: 0440
+            items:
+              - key: private-key.pem
+                path: private-key.pem
+        - name: trust
+          secret:
+            secretName: hermes-friend-trust
+            defaultMode: 0440
+            items:
+              - key: approval-public-key
+                path: approval-public-key
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi

--- a/kubernetes/apps/hermes-friends-code/runner/app/kustomization.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./storage.yaml
+  - ./deployments.yaml
+  - ./services.yaml
+  - ./servicemonitors.yaml
+  - ./prometheusrules.yaml

--- a/kubernetes/apps/hermes-friends-code/runner/app/prometheusrules.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/prometheusrules.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hermes-friends-code
+  namespace: hermes-friends-control
+spec:
+  groups:
+    - name: hermes-friends-code.workloads
+      rules:
+        - alert: HermesFriendRunnerWorkloadUnavailable
+          expr: >-
+            kube_deployment_spec_replicas{namespace=~"hermes-friends-(control|artifact|creator|publisher)",deployment=~"hermes-friend-(dispatcher|artifactd|creator|publisher)"} > 0
+            and on (namespace, deployment)
+            kube_deployment_status_replicas_available{namespace=~"hermes-friends-(control|artifact|creator|publisher)",deployment=~"hermes-friend-(dispatcher|artifactd|creator|publisher)"}
+            < kube_deployment_spec_replicas{namespace=~"hermes-friends-(control|artifact|creator|publisher)",deployment=~"hermes-friend-(dispatcher|artifactd|creator|publisher)"}
+          for: 10m
+          labels:
+            severity: critical
+            service: hermes-friends-code
+          annotations:
+            summary: A friend public-code runner component is unavailable
+            description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has fewer available replicas than requested.
+        - alert: HermesFriendSandboxJobFailed
+          expr: kube_job_status_failed{namespace="hermes-friends-sandbox"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            service: hermes-friends-code
+          annotations:
+            summary: A friend public-code sandbox Job failed
+            description: Sandbox Job {{ $labels.job_name }} has remained failed for five minutes.
+        - alert: HermesFriendRunnerMetricsMissing
+          expr: >-
+            kube_deployment_spec_replicas{namespace=~"hermes-friends-(control|artifact|creator|publisher)",deployment=~"hermes-friend-(dispatcher|artifactd|creator|publisher)"} > 0
+            unless on (namespace, deployment)
+            label_replace(
+              max by (namespace, job) (up{namespace=~"hermes-friends-(control|artifact|creator|publisher)",job=~"hermes-friend-(dispatcher|artifactd|creator|publisher)"} == 1),
+              "deployment", "$1", "job", "(.+)"
+            )
+          for: 5m
+          labels:
+            severity: critical
+            service: hermes-friends-code
+          annotations:
+            summary: A running friend-code component has no healthy metrics target
+            description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} is requested but has not produced a healthy Prometheus scrape for five minutes.
+        - alert: HermesFriendSandboxJobStuck
+          expr: >-
+            (time() - kube_job_status_start_time{namespace="hermes-friends-sandbox"} > 1200)
+            and on (namespace, job_name)
+            kube_job_status_active{namespace="hermes-friends-sandbox"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            service: hermes-friends-code
+          annotations:
+            summary: A friend public-code sandbox Job is stuck
+            description: Sandbox Job {{ $labels.job_name }} has remained active for more than twenty minutes.
+        - alert: HermesFriendRunnerContainerRestarting
+          expr: >-
+            increase(kube_pod_container_status_restarts_total{namespace=~"hermes-friends-(control|artifact|creator|publisher)",container=~"dispatcher|artifactd|creator|publisher"}[15m]) > 1
+          for: 5m
+          labels:
+            severity: warning
+            service: hermes-friends-code
+          annotations:
+            summary: A friend-code control component is restarting
+            description: Container {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} restarted repeatedly in the last fifteen minutes.
+        - alert: HermesFriendSandboxQuotaExhausted
+          expr: >-
+            kube_resourcequota{namespace="hermes-friends-sandbox",resource=~"pods|count/jobs.batch",type="used"}
+            >= on (namespace, resource)
+            kube_resourcequota{namespace="hermes-friends-sandbox",resource=~"pods|count/jobs.batch",type="hard"}
+          for: 5m
+          labels:
+            severity: warning
+            service: hermes-friends-code
+          annotations:
+            summary: The friend sandbox exhausted a concurrency quota
+            description: Sandbox {{ $labels.resource }} usage has remained at its hard quota for five minutes.
+        - alert: HermesFriendKataValidationMissing
+          expr: absent(kube_job_status_succeeded{namespace="hermes-friends-runtime",job_name="hermes-friends-kata-validation"} == 1)
+          for: 10m
+          labels:
+            severity: critical
+            service: hermes-friends-code
+          annotations:
+            summary: The accepted Kata runtime proof is missing
+            description: The retained one-shot Kata validation Job is not recorded as successful while friend-code workloads exist.
+        - alert: HermesFriendPersistentVolumeNearlyFull
+          expr: >-
+            kubelet_volume_stats_used_bytes{namespace=~"hermes-friends-(control|artifact)",persistentvolumeclaim=~"hermes-friend-(dispatcher-journal|artifacts)"}
+            /
+            kubelet_volume_stats_capacity_bytes{namespace=~"hermes-friends-(control|artifact)",persistentvolumeclaim=~"hermes-friend-(dispatcher-journal|artifacts)"} > 0.85
+          for: 15m
+          labels:
+            severity: warning
+            service: hermes-friends-code
+          annotations:
+            summary: A friend-code persistent volume is nearly full
+            description: PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has stayed above 85% utilization for fifteen minutes.

--- a/kubernetes/apps/hermes-friends-code/runner/app/servicemonitors.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/servicemonitors.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hermes-friend-dispatcher
+  namespace: hermes-friends-control
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames: [hermes-friends-control]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-dispatcher
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hermes-friend-artifactd
+  namespace: hermes-friends-artifact
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames: [hermes-friends-artifact]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-artifactd
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hermes-friend-creator
+  namespace: hermes-friends-creator
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames: [hermes-friends-creator]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-creator
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hermes-friend-publisher
+  namespace: hermes-friends-publisher
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames: [hermes-friends-publisher]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-publisher
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/kubernetes/apps/hermes-friends-code/runner/app/services.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/services.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-friend-dispatcher
+  namespace: hermes-friends-control
+  labels:
+    app.kubernetes.io/name: hermes-friend-dispatcher
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hermes-friend-dispatcher
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-friend-artifactd
+  namespace: hermes-friends-artifact
+  labels:
+    app.kubernetes.io/name: hermes-friend-artifactd
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hermes-friend-artifactd
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-friend-creator
+  namespace: hermes-friends-creator
+  labels:
+    app.kubernetes.io/name: hermes-friend-creator
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hermes-friend-creator
+  ports:
+    - name: http
+      port: 8082
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-friend-publisher
+  namespace: hermes-friends-publisher
+  labels:
+    app.kubernetes.io/name: hermes-friend-publisher
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hermes-friend-publisher
+  ports:
+    - name: http
+      port: 8083
+      targetPort: http

--- a/kubernetes/apps/hermes-friends-code/runner/app/storage.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/app/storage.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-friend-dispatcher-journal
+  namespace: hermes-friends-control
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-friend-artifacts
+  namespace: hermes-friends-artifact
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/hermes-friends-code/runner/boundary/app/admission-policy.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/boundary/app/admission-policy.yaml
@@ -1,0 +1,268 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: hermes-friends-sandbox-jobs
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [batch]
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [jobs]
+        scope: Namespaced
+  validations:
+    - expression: >-
+        has(object.metadata.labels) &&
+        size(object.metadata.labels) == 5 &&
+        object.metadata.labels['app.kubernetes.io/name'] == 'hermes-friend-sandbox' &&
+        object.metadata.labels['app.kubernetes.io/managed-by'] == 'hermes-friend-dispatcher' &&
+        object.metadata.labels['hermes.davidapps.dev/friend-role'] in ['generator', 'tester'] &&
+        object.metadata.labels['app.kubernetes.io/component'] == object.metadata.labels['hermes.davidapps.dev/friend-role'] &&
+        object.metadata.labels['hermes.davidapps.dev/approval-hash'].matches('^[0-9a-f]{64}$') &&
+        has(object.spec.template.metadata.labels) &&
+        object.spec.template.metadata.labels['app.kubernetes.io/name'] == object.metadata.labels['app.kubernetes.io/name'] &&
+        object.spec.template.metadata.labels['app.kubernetes.io/component'] == object.metadata.labels['app.kubernetes.io/component'] &&
+        object.spec.template.metadata.labels['app.kubernetes.io/managed-by'] == object.metadata.labels['app.kubernetes.io/managed-by'] &&
+        object.spec.template.metadata.labels['hermes.davidapps.dev/friend-role'] == object.metadata.labels['hermes.davidapps.dev/friend-role'] &&
+        object.spec.template.metadata.labels['hermes.davidapps.dev/approval-hash'] == object.metadata.labels['hermes.davidapps.dev/approval-hash'] &&
+        has(object.metadata.annotations) && size(object.metadata.annotations) == 3 &&
+        object.metadata.annotations['hermes.davidapps.dev/approval-hash'] == object.metadata.labels['hermes.davidapps.dev/approval-hash'] &&
+        object.metadata.annotations['hermes.davidapps.dev/image-digest'].matches('^sha256:[0-9a-f]{64}$') &&
+        int(object.metadata.annotations['hermes.davidapps.dev/pid-limit']) >= 16 &&
+        int(object.metadata.annotations['hermes.davidapps.dev/pid-limit']) <= 512 &&
+        has(object.spec.template.metadata.annotations) &&
+        object.spec.template.metadata.annotations == object.metadata.annotations
+      message: only exact dispatcher-managed, approval-bound generator and tester Jobs are permitted
+    - expression: >-
+        object.metadata.name == 'friend-' + object.metadata.labels['hermes.davidapps.dev/friend-role'] + '-' +
+        object.metadata.labels['hermes.davidapps.dev/approval-hash'].substring(0, 20)
+      message: the Job name must match its role and signed approval hash
+    - expression: >-
+        object.spec.backoffLimit == 0 &&
+        (!has(object.spec.parallelism) || object.spec.parallelism == 1) &&
+        (!has(object.spec.completions) || object.spec.completions == 1) &&
+        (!has(object.spec.suspend) || object.spec.suspend == false) &&
+        has(object.spec.activeDeadlineSeconds) && object.spec.activeDeadlineSeconds > 0 &&
+        ((object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'generator' && object.spec.activeDeadlineSeconds <= 3600) ||
+         (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'tester' && object.spec.activeDeadlineSeconds <= 1800)) &&
+        object.spec.ttlSecondsAfterFinished == 600
+      message: Jobs must be single-run, role-deadline bounded, and collected after ten minutes
+    - expression: >-
+        object.spec.template.spec.restartPolicy == 'Never' &&
+        object.spec.template.spec.serviceAccountName == 'hermes-friend-sandbox' &&
+        object.spec.template.spec.automountServiceAccountToken == false &&
+        object.spec.template.spec.enableServiceLinks == false &&
+        object.spec.template.spec.runtimeClassName == 'kata-qemu' &&
+        has(object.spec.template.spec.dnsConfig) &&
+        size(object.spec.template.spec.dnsConfig.options) == 1 &&
+        object.spec.template.spec.dnsConfig.options[0].name == 'ndots' &&
+        object.spec.template.spec.dnsConfig.options[0].value == '1' &&
+        (!has(object.spec.template.spec.imagePullSecrets) || size(object.spec.template.spec.imagePullSecrets) == 0) &&
+        (!has(object.spec.template.spec.hostAliases) || size(object.spec.template.spec.hostAliases) == 0) &&
+        !has(object.spec.template.spec.nodeName) &&
+        !has(object.spec.template.spec.priorityClassName) &&
+        !object.spec.template.spec.hostNetwork && !object.spec.template.spec.hostPID && !object.spec.template.spec.hostIPC
+      message: Jobs must use the tokenless sandbox identity, reviewed Kata RuntimeClass, and host isolation
+    - expression: >-
+        size(object.spec.template.spec.containers) == 1 &&
+        (!has(object.spec.template.spec.initContainers) || size(object.spec.template.spec.initContainers) == 0) &&
+        (!has(object.spec.template.spec.ephemeralContainers) || size(object.spec.template.spec.ephemeralContainers) == 0)
+      message: Jobs may contain exactly one regular container
+    - expression: >-
+        (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'generator' &&
+         object.spec.template.spec.containers[0].name == 'generator' &&
+         object.spec.template.spec.containers[0].image == 'ghcr.io/davidilie/hermes-friend-generator@sha256:0000000000000000000000000000000000000000000000000000000000000000' &&
+         object.spec.template.spec.containers[0].imagePullPolicy == 'IfNotPresent' &&
+         object.metadata.annotations['hermes.davidapps.dev/image-digest'] == 'sha256:0000000000000000000000000000000000000000000000000000000000000000' &&
+         object.spec.template.spec.containers[0].command == ['/hermes-friend-runner'] &&
+         object.spec.template.spec.containers[0].args == ['generate', '--input=/input/request.json', '--pid-limit=' + object.metadata.annotations['hermes.davidapps.dev/pid-limit'], '--model-relay=http://hermes-friend-model-relay.hermes-friends-control.svc.cluster.local:8084', '--artifact=http://hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local:8081']) ||
+        (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'tester' &&
+         object.spec.template.spec.containers[0].name == 'tester' &&
+         object.spec.template.spec.containers[0].image == 'ghcr.io/davidilie/hermes-friend-tester@sha256:0000000000000000000000000000000000000000000000000000000000000000' &&
+         object.spec.template.spec.containers[0].imagePullPolicy == 'IfNotPresent' &&
+         object.metadata.annotations['hermes.davidapps.dev/image-digest'] == 'sha256:0000000000000000000000000000000000000000000000000000000000000000' &&
+         object.spec.template.spec.containers[0].command == ['/hermes-friend-runner'] &&
+         object.spec.template.spec.containers[0].args == ['test', '--input=/input/request.json', '--pid-limit=' + object.metadata.annotations['hermes.davidapps.dev/pid-limit'], '--catalog=/config/tests.json', '--work=/work', '--artifact=http://hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local:8081'])
+      message: the role, immutable image, and command must match the reviewed shape
+    - expression: >-
+        has(object.spec.template.spec.securityContext) &&
+        object.spec.template.spec.securityContext.runAsNonRoot == true &&
+        object.spec.template.spec.securityContext.runAsUser == 65532 &&
+        object.spec.template.spec.securityContext.runAsGroup == 65532 &&
+        object.spec.template.spec.securityContext.fsGroup == 65532 &&
+        object.spec.template.spec.securityContext.seccompProfile.type == 'RuntimeDefault'
+      message: the Pod security context must enforce non-root RuntimeDefault execution
+    - expression: >-
+        object.spec.template.spec.containers.all(container,
+          has(container.securityContext) &&
+          container.securityContext.allowPrivilegeEscalation == false &&
+          container.securityContext.readOnlyRootFilesystem == true &&
+          has(container.securityContext.capabilities) &&
+          container.securityContext.capabilities.drop == ['ALL'] &&
+          has(container.resources.requests) && has(container.resources.limits) &&
+          'cpu' in container.resources.requests && 'memory' in container.resources.requests && 'ephemeral-storage' in container.resources.requests &&
+          'cpu' in container.resources.limits && 'memory' in container.resources.limits && 'ephemeral-storage' in container.resources.limits &&
+          container.resources.requests == container.resources.limits &&
+          (!has(container.env) || size(container.env) == 0) &&
+          (!has(container.envFrom) || size(container.envFrom) == 0) &&
+          (!has(container.volumeDevices) || size(container.volumeDevices) == 0) &&
+          !has(container.lifecycle) && !has(container.livenessProbe) && !has(container.readinessProbe) && !has(container.startupProbe))
+      message: containers require a read-only restricted context and explicit resource bounds
+    - expression: >-
+        has(object.spec.template.spec.volumes) &&
+        ((object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'generator' && size(object.spec.template.spec.volumes) == 2) ||
+         (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'tester' && size(object.spec.template.spec.volumes) == 3)) &&
+        object.spec.template.spec.volumes.all(volume, volume.name in ['input', 'config', 'work']) &&
+        size(object.spec.template.spec.volumes.filter(volume,
+          volume.name == 'input' && has(volume.configMap) && volume.configMap.name == object.metadata.name && volume.configMap.defaultMode == 292)) == 1 &&
+        size(object.spec.template.spec.volumes.filter(volume,
+          volume.name == 'work' && has(volume.emptyDir) && has(volume.emptyDir.sizeLimit) &&
+          volume.emptyDir.sizeLimit == object.spec.template.spec.containers[0].resources.limits['ephemeral-storage'])) == 1 &&
+        ((object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'generator' &&
+          !object.spec.template.spec.volumes.exists(volume, volume.name == 'config')) ||
+         (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'tester' &&
+          size(object.spec.template.spec.volumes.filter(volume,
+            volume.name == 'config' && has(volume.configMap) && volume.configMap.name == 'UNSET' && volume.configMap.defaultMode == 292)) == 1))
+      message: only the exact input, bounded work, and tester catalog volumes are permitted
+    - expression: >-
+        size(object.spec.template.spec.containers[0].volumeMounts) ==
+          (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'generator' ? 2 : 3) &&
+        size(object.spec.template.spec.containers[0].volumeMounts.filter(mount,
+          mount.name == 'input' && mount.mountPath == '/input' && mount.readOnly == true)) == 1 &&
+        size(object.spec.template.spec.containers[0].volumeMounts.filter(mount,
+          mount.name == 'work' && mount.mountPath == '/work' && (!has(mount.readOnly) || mount.readOnly == false))) == 1 &&
+        ((object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'generator' &&
+          !object.spec.template.spec.containers[0].volumeMounts.exists(mount, mount.name == 'config')) ||
+         (object.metadata.labels['hermes.davidapps.dev/friend-role'] == 'tester' &&
+          size(object.spec.template.spec.containers[0].volumeMounts.filter(mount,
+            mount.name == 'config' && mount.mountPath == '/config' && mount.readOnly == true)) == 1))
+      message: Jobs cannot consume Secrets or mount paths outside the exact stage contract
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: hermes-friends-sandbox-jobs
+spec:
+  policyName: hermes-friends-sandbox-jobs
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: hermes-friends-sandbox
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: hermes-friends-sandbox-inputs
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: [v1]
+        operations: [CREATE]
+        resources: [configmaps]
+        scope: Namespaced
+  matchConditions:
+    - name: dispatcher-identity
+      expression: request.userInfo.username == 'system:serviceaccount:hermes-friends-control:hermes-friend-dispatcher'
+  validations:
+    - expression: >-
+        has(object.metadata.labels) &&
+        size(object.metadata.labels) == 4 &&
+        object.metadata.labels['app.kubernetes.io/name'] == 'hermes-friend-sandbox' &&
+        object.metadata.labels['app.kubernetes.io/component'] == 'input' &&
+        object.metadata.labels['app.kubernetes.io/managed-by'] == 'hermes-friend-dispatcher' &&
+        object.metadata.labels['hermes.davidapps.dev/approval-hash'].matches('^[0-9a-f]{64}$') &&
+        (object.metadata.name == 'friend-generator-' + object.metadata.labels['hermes.davidapps.dev/approval-hash'].substring(0, 20) ||
+         object.metadata.name == 'friend-tester-' + object.metadata.labels['hermes.davidapps.dev/approval-hash'].substring(0, 20)) &&
+        object.immutable == true &&
+        has(object.data) && size(object.data) == 1 && 'request.json' in object.data &&
+        (!has(object.binaryData) || size(object.binaryData) == 0) &&
+        (!has(object.metadata.annotations) || size(object.metadata.annotations) == 0)
+      message: dispatcher ConfigMaps are immutable single-request inputs with the exact managed shape
+    - expression: >-
+        size(object.metadata.ownerReferences) == 1 &&
+        object.metadata.ownerReferences[0].apiVersion == 'batch/v1' &&
+        object.metadata.ownerReferences[0].kind == 'Job' &&
+        object.metadata.ownerReferences[0].name == object.metadata.name &&
+        size(object.metadata.ownerReferences[0].uid) > 0 &&
+        object.metadata.ownerReferences[0].controller == true &&
+        object.metadata.ownerReferences[0].blockOwnerDeletion == false
+      message: input ConfigMap creation requires the observed same-name Job controller owner
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: hermes-friends-sandbox-inputs
+spec:
+  policyName: hermes-friends-sandbox-inputs
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: hermes-friends-sandbox
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: hermes-friends-kata-validation
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [batch]
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [jobs]
+        scope: Namespaced
+  validations:
+    - expression: >-
+        object.metadata.name == 'hermes-friends-kata-validation' &&
+        object.metadata.labels['hermes.davidapps.dev/activation-revision'].matches('^[a-z0-9][a-z0-9._-]{0,63}$') &&
+        object.spec.template.metadata.labels['hermes.davidapps.dev/activation-revision'] == object.metadata.labels['hermes.davidapps.dev/activation-revision'] &&
+        object.spec.backoffLimit == 0 && object.spec.completions == 1 && object.spec.parallelism == 1 &&
+        object.spec.activeDeadlineSeconds > 0 && object.spec.activeDeadlineSeconds <= 120 &&
+        !has(object.spec.ttlSecondsAfterFinished) &&
+        object.spec.template.spec.runtimeClassName == 'kata-qemu' &&
+        object.spec.template.spec.serviceAccountName == 'hermes-friends-runtime-validator' &&
+        object.spec.template.spec.automountServiceAccountToken == false &&
+        object.spec.template.spec.enableServiceLinks == false &&
+        object.spec.template.spec.restartPolicy == 'Never' &&
+        !object.spec.template.spec.hostNetwork && !object.spec.template.spec.hostPID && !object.spec.template.spec.hostIPC &&
+        size(object.spec.template.spec.containers) == 1 &&
+        (!has(object.spec.template.spec.initContainers) || size(object.spec.template.spec.initContainers) == 0) &&
+        (!has(object.spec.template.spec.ephemeralContainers) || size(object.spec.template.spec.ephemeralContainers) == 0) &&
+        object.spec.template.spec.containers[0].image.matches('^ghcr.io/davidilie/hermes-friend-runtime-validator@sha256:[0-9a-f]{64}$') &&
+        object.spec.template.spec.containers[0].image != 'ghcr.io/davidilie/hermes-friend-runtime-validator@sha256:0000000000000000000000000000000000000000000000000000000000000000' &&
+        object.spec.template.spec.containers[0].command == ['/hermes-friend-runtime-validator'] &&
+        object.spec.template.spec.containers[0].args == ['validate', '--runtime-class=kata-qemu'] &&
+        (!has(object.spec.template.spec.containers[0].env) || size(object.spec.template.spec.containers[0].env) == 0) &&
+        (!has(object.spec.template.spec.containers[0].envFrom) || size(object.spec.template.spec.containers[0].envFrom) == 0) &&
+        object.spec.template.spec.securityContext.runAsNonRoot == true &&
+        object.spec.template.spec.securityContext.runAsUser == 65532 &&
+        object.spec.template.spec.securityContext.runAsGroup == 65532 &&
+        object.spec.template.spec.securityContext.seccompProfile.type == 'RuntimeDefault' &&
+        object.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation == false &&
+        object.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem == true &&
+        object.spec.template.spec.containers[0].securityContext.capabilities.drop == ['ALL'] &&
+        size(object.spec.template.spec.volumes) == 1 && object.spec.template.spec.volumes[0].name == 'tmp' &&
+        has(object.spec.template.spec.volumes[0].emptyDir) &&
+        size(object.spec.template.spec.containers[0].volumeMounts) == 1 &&
+        object.spec.template.spec.containers[0].volumeMounts[0].name == 'tmp' &&
+        object.spec.template.spec.containers[0].volumeMounts[0].mountPath == '/tmp'
+      message: activation requires the exact one-shot Kata validation Job with a reviewed non-inert digest
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: hermes-friends-kata-validation
+spec:
+  policyName: hermes-friends-kata-validation
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: hermes-friends-runtime

--- a/kubernetes/apps/hermes-friends-code/runner/boundary/app/kustomization.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/boundary/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./serviceaccounts.yaml
+  - ./rbac.yaml
+  - ./quotas.yaml
+  - ./networkpolicies.yaml
+  - ./admission-policy.yaml

--- a/kubernetes/apps/hermes-friends-code/runner/boundary/app/networkpolicies.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/boundary/app/networkpolicies.yaml
@@ -1,0 +1,474 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-friends-control
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-friends-sandbox
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-friends-runtime
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-friends-artifact
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-friends-creator
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-friends-publisher
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dispatcher-egress
+  namespace: hermes-friends-control
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-dispatcher
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-broker
+      ports:
+        - port: 8080
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-artifact
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-artifactd
+      ports:
+        - port: 8081
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-creator
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-creator
+      ports:
+        - port: 8082
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-publisher
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-publisher
+      ports:
+        - port: 8083
+          protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dispatcher-dns
+  namespace: hermes-friends-control
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-dispatcher
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchName: hermes-friend-broker.default.svc.cluster.local
+              - matchName: hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local
+              - matchName: hermes-friend-creator.hermes-friends-creator.svc.cluster.local
+              - matchName: hermes-friend-publisher.hermes-friends-publisher.svc.cluster.local
+              - matchName: hermes-friend-model-relay.hermes-friends-control.svc.cluster.local
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dispatcher-kube-api
+  namespace: hermes-friends-control
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-dispatcher
+  egress:
+    - toEntities: [kube-apiserver]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-artifact-egress
+  namespace: hermes-friends-sandbox
+spec:
+  podSelector:
+    matchExpressions:
+      - key: hermes.davidapps.dev/friend-role
+        operator: In
+        values: [generator, tester]
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-artifact
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-artifactd
+      ports:
+        - port: 8081
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: generator-model-relay-egress
+  namespace: hermes-friends-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      hermes.davidapps.dev/friend-role: generator
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-control
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-model-relay
+      ports:
+        - port: 8084
+          protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sandbox-dns
+  namespace: hermes-friends-sandbox
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: hermes.davidapps.dev/friend-role
+        operator: In
+        values: [generator, tester]
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchName: hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local
+              - matchName: hermes-friend-model-relay.hermes-friends-control.svc.cluster.local
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: artifactd-ingress
+  namespace: hermes-friends-artifact
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-artifactd
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-control
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-dispatcher
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-sandbox
+          podSelector:
+            matchExpressions:
+              - key: hermes.davidapps.dev/friend-role
+                operator: In
+                values: [generator, tester]
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-publisher
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-publisher
+      ports:
+        - port: 8081
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: creator-ingress
+  namespace: hermes-friends-creator
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-creator
+  policyTypes: [Ingress]
+  ingress:
+    - from: &dispatcher-source
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-control
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-dispatcher
+      ports:
+        - port: 8082
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: publisher-ingress
+  namespace: hermes-friends-publisher
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-publisher
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-control
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-dispatcher
+      ports:
+        - port: 8083
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: publisher-artifact-egress
+  namespace: hermes-friends-publisher
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-publisher
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes-friends-artifact
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: hermes-friend-artifactd
+      ports:
+        - port: 8081
+          protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: github-api
+  namespace: hermes-friends-creator
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-creator
+  egress: &github-egress
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchName: api.github.com
+    - toFQDNs:
+        - matchName: api.github.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: github-api
+  namespace: hermes-friends-publisher
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-publisher
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchName: api.github.com
+              - matchName: hermes-friend-artifactd.hermes-friends-artifact.svc.cluster.local
+    - toFQDNs:
+        - matchName: api.github.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-scrape
+  namespace: hermes-friends-control
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-dispatcher
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: ^/metrics$
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-scrape
+  namespace: hermes-friends-artifact
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-artifactd
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "8081"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: ^/metrics$
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-scrape
+  namespace: hermes-friends-creator
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-creator
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "8082"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: ^/metrics$
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-scrape
+  namespace: hermes-friends-publisher
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hermes-friend-publisher
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "8083"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: ^/metrics$

--- a/kubernetes/apps/hermes-friends-code/runner/boundary/app/quotas.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/boundary/app/quotas.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: hermes-friends-control
+  namespace: hermes-friends-control
+spec:
+  hard:
+    pods: "2"
+    persistentvolumeclaims: "1"
+    requests.storage: 2Gi
+    requests.cpu: "1"
+    requests.memory: 1Gi
+    limits.cpu: "2"
+    limits.memory: 2Gi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: hermes-friends-sandbox
+  namespace: hermes-friends-sandbox
+spec:
+  hard:
+    pods: "4"
+    count/jobs.batch: "4"
+    count/configmaps: "16"
+    requests.cpu: "4"
+    requests.memory: 4Gi
+    requests.ephemeral-storage: 4Gi
+    limits.cpu: "8"
+    limits.memory: 8Gi
+    limits.ephemeral-storage: 8Gi
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: hermes-friends-sandbox
+  namespace: hermes-friends-sandbox
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+        ephemeral-storage: 128Mi
+      default:
+        cpu: "1"
+        memory: 1Gi
+        ephemeral-storage: 1Gi
+      max:
+        cpu: "2"
+        memory: 2Gi
+        ephemeral-storage: 2Gi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: hermes-friends-runtime
+  namespace: hermes-friends-runtime
+spec:
+  hard:
+    pods: "1"
+    count/jobs.batch: "1"
+    requests.cpu: 100m
+    requests.memory: 128Mi
+    requests.ephemeral-storage: 128Mi
+    limits.cpu: 250m
+    limits.memory: 256Mi
+    limits.ephemeral-storage: 256Mi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: hermes-friends-artifact
+  namespace: hermes-friends-artifact
+spec:
+  hard:
+    pods: "1"
+    persistentvolumeclaims: "1"
+    requests.storage: 4Gi
+    requests.cpu: "1"
+    requests.memory: 1Gi
+    limits.cpu: "2"
+    limits.memory: 2Gi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: hermes-friends-creator
+  namespace: hermes-friends-creator
+spec:
+  hard:
+    pods: "1"
+    requests.cpu: 500m
+    requests.memory: 512Mi
+    limits.cpu: "1"
+    limits.memory: 1Gi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: hermes-friends-publisher
+  namespace: hermes-friends-publisher
+spec:
+  hard:
+    pods: "1"
+    requests.cpu: "1"
+    requests.memory: 1Gi
+    limits.cpu: "2"
+    limits.memory: 2Gi

--- a/kubernetes/apps/hermes-friends-code/runner/boundary/app/rbac.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/boundary/app/rbac.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hermes-friend-dispatcher
+  namespace: hermes-friends-sandbox
+rules:
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [create, get]
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [create, get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hermes-friend-dispatcher
+  namespace: hermes-friends-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hermes-friend-dispatcher
+subjects:
+  - kind: ServiceAccount
+    name: hermes-friend-dispatcher
+    namespace: hermes-friends-control
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-friend-runtimeclass-reader
+rules:
+  - apiGroups: [node.k8s.io]
+    resources: [runtimeclasses]
+    resourceNames: [kata-qemu]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-friend-runtimeclass-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-friend-runtimeclass-reader
+subjects:
+  - kind: ServiceAccount
+    name: hermes-friend-dispatcher
+    namespace: hermes-friends-control

--- a/kubernetes/apps/hermes-friends-code/runner/boundary/app/serviceaccounts.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/boundary/app/serviceaccounts.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-friend-dispatcher
+  namespace: hermes-friends-control
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-friend-sandbox
+  namespace: hermes-friends-sandbox
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-friends-runtime-validator
+  namespace: hermes-friends-runtime
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-friend-artifactd
+  namespace: hermes-friends-artifact
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-friend-creator
+  namespace: hermes-friends-creator
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-friend-publisher
+  namespace: hermes-friends-publisher
+automountServiceAccountToken: false

--- a/kubernetes/apps/hermes-friends-code/runner/ks.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/ks.yaml
@@ -1,0 +1,70 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes-friends-code-boundary
+  namespace: flux-system
+spec:
+  # Activation is deliberately three-step. Apply and prove the deny boundary
+  # before any validation or workload object can exist.
+  suspend: true
+  dependsOn:
+    - name: cilium
+      namespace: kube-system
+  path: ./kubernetes/apps/hermes-friends-code/runner/boundary/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes-friends-code-runtime-validation
+  namespace: flux-system
+spec:
+  suspend: true
+  dependsOn:
+    - name: hermes-friends-code-boundary
+  path: ./kubernetes/apps/hermes-friends-code/runner/runtime-validation/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes-friends-code
+  namespace: flux-system
+spec:
+  # Do not unsuspend until the one-shot Kata validation Kustomization is Ready
+  # at the exact activation revision and David has approved the final policy.
+  suspend: true
+  dependsOn:
+    - name: openebs
+      namespace: openebs-system
+    - name: prometheus-operator-crds
+      namespace: observability
+    - name: hermes-friends-code-runtime-validation
+  path: ./kubernetes/apps/hermes-friends-code/runner/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/hermes-friends-code/runner/runtime-validation/app/job.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/runtime-validation/app/job.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hermes-friends-kata-validation
+  namespace: hermes-friends-runtime
+  labels:
+    app.kubernetes.io/name: hermes-friends-kata-validation
+    hermes.davidapps.dev/activation-revision: UNSET
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hermes-friends-kata-validation
+        hermes.davidapps.dev/activation-revision: UNSET
+    spec:
+      runtimeClassName: kata-qemu
+      serviceAccountName: hermes-friends-runtime-validator
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: validate
+          # The inert digest prevents accidental execution. Activation must
+          # pin a reviewed validator and replace both UNSET revision labels.
+          image: ghcr.io/davidilie/hermes-friend-runtime-validator@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          command: [/hermes-friend-runtime-validator]
+          args: [validate, --runtime-class=kata-qemu]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+              ephemeral-storage: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+              ephemeral-storage: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 16Mi

--- a/kubernetes/apps/hermes-friends-code/runner/runtime-validation/app/kustomization.yaml
+++ b/kubernetes/apps/hermes-friends-code/runner/runtime-validation/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./job.yaml


### PR DESCRIPTION
## Summary

- stage six isolated namespaces for control, sandbox, runtime validation, artifacts, repository creation, and draft-PR publishing
- split the rollout into three suspended Flux Kustomizations: boundary, Kata validation, then workloads
- pin the reviewed source contract for separate generator and tester images, exact commands, signed PID limits, tokenless Jobs, bounded resources, immutable input ConfigMaps, Job owner references, and ten-minute TTL cleanup
- limit dispatcher RBAC to create/get on sandbox Jobs and ConfigMaps plus get on the named `kata-qemu` RuntimeClass
- add fail-closed admission policies for sandbox Jobs, dispatcher-created inputs, and the one-shot Kata proof
- add default-deny policies, exact DNS names, GitHub API-only external egress, and L7 `GET /metrics`-only Prometheus ingress
- add quotas, PVCs, Services, ServiceMonitors, and alerts without adding any Secret values

## Zero-live staging behavior

This branch is not referenced by `kubernetes/apps/kustomization.yaml`. Merging it creates no Namespace, Flux object, Pod, PVC, broker rollout, or other live object.

The existing Hermes friend broker HelmRelease and NetworkPolicy are unchanged. Its source runner API remains disabled by default.

All three child Flux Kustomizations have `spec.suspend: true`. All four Deployments use zero replicas. Every image uses an inert all-zero digest. No Secret, Ingress, HTTPRoute, model relay, generator Job, or tester Job is included.

## Activation blockers

A later activation PR must install and accept `RuntimeClass/kata-qemu`, pin a reviewed runtime validator and real component digests, configure the test catalog and public-only model relay, provision separate encrypted GitHub App identities, and require a fresh David approval against the final policy hash.

The live read-only preflight confirms that `RuntimeClass/kata-qemu` is currently absent. The workload Kustomization cannot become Ready before the retained one-shot Kata validation succeeds.

## Validation

- `hack/validate-hermes-friends-code`: passed
- focused Kustomize builds for root, boundary, runtime validation, and workloads: passed
- strict kubeconform: 73 resources, 56 valid, 0 invalid, 0 errors, 17 CRD-backed resources skipped because local schemas are unavailable
- Kubernetes server-side dry-run compiled all three ValidatingAdmissionPolicies and bindings; nothing was persisted
- `go test ./internal/friendrunner` against source PR commit `35af498d504628ba4a0451fa86cbd86268a3a553`: passed
- repository Flux Local test: 204 passed
- `git diff --check`: passed

No merge, reconciliation, rollout, credential change, or live cluster mutation was performed.
