### PR TITLE
fix(grafana): match OTel acquisition ratio gauges

### DIFF
--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-overview.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-overview.json
@@ -1249,7 +1249,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\"}))",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_(1|ratio))?\",service_name=\"zerocut\"}))",
           "instant": true,
           "legendFormat": "known acquisitions",
           "range": false,
@@ -1286,7 +1286,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_(1|ratio))?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
           "instant": true,
           "legendFormat": "active acquisitions",
           "range": false,
@@ -1373,7 +1373,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "prometheus-davidapps-cluster" },
           "editorMode": "code",
-          "expr": "min({__name__=~\"zerocut_acquisition_snapshot_success(_1)?\",service_name=\"zerocut\"})",
+          "expr": "min({__name__=~\"zerocut_acquisition_snapshot_success(_(1|ratio))?\",service_name=\"zerocut\"})",
           "instant": true,
           "legendFormat": "snapshot",
           "range": false,
@@ -1460,6 +1460,6 @@
   "timezone": "browser",
   "title": "Overview",
   "uid": "zerocut-overview",
-  "version": 5,
+  "version": 6,
   "weekStart": ""
 }

--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-revenue.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-revenue.json
@@ -873,7 +873,7 @@
             "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\"}))",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_(1|ratio))?\",service_name=\"zerocut\"}))",
           "instant": true,
           "legendFormat": "known acquisitions",
           "range": false,
@@ -937,7 +937,7 @@
             "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_1)?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
+          "expr": "sum(max by (revenue_product, acquisition_status, commerce_provider, commerce_currency) ({__name__=~\"zerocut_acquisition_count(_(1|ratio))?\",service_name=\"zerocut\",acquisition_status=\"active\"}))",
           "instant": true,
           "legendFormat": "active acquisitions",
           "range": false,
@@ -1075,7 +1075,7 @@
             "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "min({__name__=~\"zerocut_acquisition_snapshot_success(_1)?\",service_name=\"zerocut\"})",
+          "expr": "min({__name__=~\"zerocut_acquisition_snapshot_success(_(1|ratio))?\",service_name=\"zerocut\"})",
           "instant": true,
           "legendFormat": "snapshot",
           "range": false,
@@ -1117,6 +1117,6 @@
   "timezone": "browser",
   "title": "Revenue & donations",
   "uid": "zerocut-revenue",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary
- match the Prometheus `_ratio` suffix emitted for dimensionless OTel gauges
- retain compatibility with unsuffixed and `_1` metric names
- bump the affected dashboard versions

## Verification
- both dashboard JSON files parse successfully
- all four acquisition PromQL expressions return live ZeroCut data
- snapshot health is 1; active acquisition count is 1; active value is 5000 USD minor units