### PR TITLE
feat(clickhouse): add Altinity canary

### DIFF
--- a/kubernetes/apps/databases/altinity-clickhouse-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/altinity-clickhouse-operator/app/helmrelease.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinity-clickhouse-operator
+spec:
+  interval: 30m
+  timeout: 15m
+  chart:
+    spec:
+      chart: altinity-clickhouse-operator
+      version: 0.27.3
+      sourceRef:
+        kind: HelmRepository
+        name: altinity
+        namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: altinity-clickhouse-operator
+    crdHook:
+      enabled: false
+    secret:
+      create: false
+    watchNamespaces:
+      - databases
+    operator:
+      image:
+        tag: "0.27.3@sha256:0520bfb8015dcb270f0600f542cad117e637cdcdc791bfd71b7964ff067d1589"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+    metrics:
+      image:
+        tag: "0.27.3@sha256:1e7c1d8167aad902513be37dcf7e439cf8a2564779a23008b8c81d879e71fb60"
+      resources:
+        requests:
+          cpu: 25m
+          memory: 96Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+    serviceMonitor:
+      enabled: true
+      keeperMetrics:
+        enabled: true
+        namespaceSelector:
+          any: false
+          matchNames:
+            - databases
+        selector:
+          clickhouse-keeper.altinity.com/Service: chk

--- a/kubernetes/apps/databases/altinity-clickhouse-operator/app/kustomization.yaml
+++ b/kubernetes/apps/databases/altinity-clickhouse-operator/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: databases
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/databases/altinity-clickhouse-operator/app/secret.sops.yaml
+++ b/kubernetes/apps/databases/altinity-clickhouse-operator/app/secret.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: altinity-clickhouse-operator
+  namespace: databases
+type: Opaque
+stringData:
+  username: ENC[AES256_GCM,data:aUZS2ADwZEWUXDwB3Q5ta9lhkg==,iv:nTT/ZDml2riK+6tRQ+KPlWbujL+Qpy9jQ7pR9SqVQ2A=,tag:KiJN8L5Owsh41jA0+2ezDA==,type:str]
+  password: ENC[AES256_GCM,data:Kob/2dysCdgOiLJfzbU95LEzVXp7ZC2A0yN61ccdV4YRvwj1/olkd7mop7AEZifp,iv:Ip69MI8vhR8mnXRJLeDpdgE3uj32Tr9tGPUoKTp+qEM=,tag:bjgi2YaBcFvkqloIiH9X8Q==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpcENxOHRQMzJzSXc1a0V6
+        b0JiTTdwcndqcGhpQkpZVnpWcFJ0UFcyOW5nCnR4ckFUa2VRanFsNTRuRktUN2Rx
+        czdDRmNvUy85bDRZRTdsWHVBQjA1cVUKLS0tIHJYMEVoWDUxNitGS0dTdWJhRkxz
+        Szk1SnA4TVlMaHRlSStxRnUwaXh2S0UKQ2qAhDS8igfHuwwOD4IcutIkGKNhsT9A
+        Jl8MMpTPyf2IQFmvUuJgpqjKzKi0EA2T+71buGVgeAURPPPBrmujKg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-25T08:44:22Z"
+  mac: ENC[AES256_GCM,data:qmR/+S9RboDs+r+p2ITyKN3jToAXNYUbhZKW3DiZBI+euY+4h8hhUo9FEIPzFKkk4pwbFfJgwuykc5+B0ghrcgVLiF6EBvJsSLN4A+/HDdNzLZ2LaJvvj+hmjk5HVv5DuB28PzRONRgVqSDbKSTPq0oqwzbZPas6fp1Wt+GjtZA=,iv:OfaUaodLiq8XORD9w+V+JskrHJYnKaDxOhcFaF7pb8I=,tag:moitXrwI9GusGKBu+IXIjA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/databases/altinity-clickhouse-operator/ks.yaml
+++ b/kubernetes/apps/databases/altinity-clickhouse-operator/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app altinity-clickhouse-operator
+  namespace: &namespace databases
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 30m
+  retryInterval: 1m
+  path: ./kubernetes/apps/databases/altinity-clickhouse-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 15m
+  wait: true

--- a/kubernetes/apps/databases/clickhouse-canary/README.md
+++ b/kubernetes/apps/databases/clickhouse-canary/README.md
@@ -1,0 +1,48 @@
+# Altinity ClickHouse canary
+
+This stack installs Altinity Operator 0.27.3 and a disposable one-shard,
+one-replica ClickHouse 26.3 installation with one Keeper. It does not select,
+mount, or modify the existing ZeroCut source ClickHouse.
+
+The canary includes a pinned `clickhouse-backup` 2.8.0 sidecar, a dedicated
+bucket-scoped MinIO credential, six-hour incremental backups, weekly full
+backups, authenticated backup metrics, and operator/ClickHouse/Keeper metrics.
+Its versioned bucket is `clickhouse-zerocut-canary-backups`.
+
+## Hardware boundary
+
+`home-cluster` has one node and only `openebs-hostpath`. It cannot prove
+multi-node placement, ZFS retention, or PVC expansion. This canary proves the
+operator, Keeper, SOPS, network, metrics, and logical backup/restore path. The
+empty davidapps target must prove the ZFS and placement gates before cutover.
+
+## Acceptance
+
+After review and merge, reconcile in dependency order:
+
+```sh
+flux reconcile kustomization altinity-clickhouse-operator -n databases --with-source
+flux reconcile kustomization clickhouse-canary -n databases
+kubectl -n databases get chi,chk,pods,pvc
+```
+
+The ClickHouse and Keeper pods must be ready, both PVCs must be bound, and the
+operator, Keeper, ClickHouse, and backup targets must be up in Prometheus.
+
+Create disposable data with the canary user, then prove a remote backup and a
+mapped restore without overwriting the source database:
+
+```sh
+pod="$(kubectl -n databases get pod -l clickhouse.altinity.com/chi=zerocut-canary -o jsonpath='{.items[0].metadata.name}')"
+password="$(kubectl -n databases get secret zerocut-canary-credentials -o jsonpath='{.data.password}' | base64 -d)"
+kubectl -n databases exec "$pod" -c clickhouse -- clickhouse-client --user zerocut_canary --password "$password" --multiquery --query "CREATE DATABASE IF NOT EXISTS backup_probe; CREATE TABLE IF NOT EXISTS backup_probe.events (id UInt64, value String) ENGINE=MergeTree ORDER BY id; INSERT INTO backup_probe.events VALUES (1, 'canary');"
+unset password
+backup="canary-manual-$(date -u +%Y%m%dT%H%M%SZ)"
+kubectl -n databases exec "$pod" -c clickhouse-backup -- clickhouse-backup create_remote '--tables=backup_probe.*' "$backup"
+kubectl -n databases exec "$pod" -c clickhouse-backup -- clickhouse-backup restore_remote --restore-database-mapping=backup_probe:backup_probe_restore "$backup"
+kubectl -n databases exec "$pod" -c clickhouse -- clickhouse-client --query "SELECT count(), groupArray(value) FROM backup_probe_restore.events"
+```
+
+Acceptance requires a count of one from the restored database and the backup
+visible in MinIO. Do not delete the canary until retained-PVC behavior and an
+operator upgrade have also been observed.

--- a/kubernetes/apps/databases/clickhouse-canary/app/backup-api.sops.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/backup-api.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zerocut-canary-backup-api
+  namespace: databases
+type: Opaque
+stringData:
+  username: ENC[AES256_GCM,data:fFhRjUeWFA==,iv:Xy8c7LDpQv+psfSJXQFd7ndSeYN/LhDU/MMzKXYCzJs=,tag:pwFfLs7VfHzOmBCeiUIQiQ==,type:str]
+  password: ENC[AES256_GCM,data:kihHx0FRRyMRxWyK+RSce19IrLnKK1YYjXEyGVGI+ZloCAGKfzos83H1sJJUalb6lKw6WHm1MQAL1sVv99DCtQ==,iv:z7P4LKRRknvcBk+nsClsPFcI2jwc47tBucJVIb83dWc=,tag:HLXjCNScP/J6SFHVTE7Riw==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsQ0Z3ZFltcVJhdEMyZlpE
+        YVk0aUpQR0FZUW05MW5lTm5NdEQzM0FvRFZnCmxyMHB5TTBOZXZnNkFCOWo0NzJl
+        SXZZZVpQNG5IakpOL0pGUndaMmZJc0UKLS0tIHh5YWI4Zm1pRWdKWlJUVExXdmQx
+        dDR0ajZra0lnbWV5c1FTdUIyWWlwMG8K7SXQl2kuBozkQpO1N8j+69HBAbEa1bq6
+        WGcCWblsSjtAmtnhTtp4QRV0jBUKxtpMwRjK8QZ5svfRvv3nSIXZKA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-25T09:16:37Z"
+  mac: ENC[AES256_GCM,data:sn90xUVaaOhZuO8dIpMIdk2TCgRp9sSGP92ctFhppgcdMnZ0KnqV2vDNMOTyxZVEnW3JU71GxqyavsiG2kch9IrHu2VE/JzH7WMGb3ftqe/t8Ei8WF6XVchYzRVZK+ih7dSusfx58hnJBxUWY5a7JR8BYVLO9497UpH6gRmT3vo=,iv:C8w+/JQdZkj2ZxUsuCFdbRiqrOiSkhDDh5EBclOUtsw=,tag:jcwHVOtbNOHCw7tKcGEU9A==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/databases/clickhouse-canary/app/backup-user.sops.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/backup-user.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zerocut-canary-backup-user
+  namespace: databases
+type: Opaque
+stringData:
+  password: ENC[AES256_GCM,data:UYz6csV0t51u8snkdkW4rk0YTvPrGHHpHIDXUW+HEgjbtuI6GEGn61opRghR2piJsVpr6gWGHpa2/19iTwU/4A==,iv:I/hnT6oNzh+l9yAMSbDsQrZLJLKKG0f7RW3JgcIKXZU=,tag:ReoNp37ODkX/dqlJQ2p32A==,type:str]
+  password_sha256_hex: ENC[AES256_GCM,data:wp8YtYU03Tl4XYRWyb2abhxZFgFBmqXNtKxynFD7qb3bbrEwjCq6YxniB3aXQCyy5O6bvPcF5Dtn+8AJ37O4Gw==,iv:/K95Q7ipb+ppkuZNV9veZQxxG0qAYWIaXcgV4Is/XBw=,tag:OR/QZDkfXD+GjBEOlli6Xw==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSREI4bzFaQU1WMkkyUXV2
+        TnlnZGlDN1RtSFA3bHFlaDlZckVmQVpjTUEwCitQSmgzMkxuWm5hTkh5MnJ2bG9H
+        elp3OGF5S2FoRG0xcXBQTVRBc0svOHcKLS0tIGo4MzVMUXBjSFA4aVdxeU5aRmIr
+        a09iS25hVlNSS2FUYm90ekJ5N1hEcDgKmP1S1rVaAGvyNrCwKNCuHTtfzAUsYXtA
+        N3azQnAxrgdlODe25z+3NWDaSyE0RPgSoANZ/ZnZa1fXU5XEJdyxXQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-25T09:16:37Z"
+  mac: ENC[AES256_GCM,data:lp6RG6TMr/IClOfncikO+Mj8BoLzDuzBxExCtSqJALMz3rLoFLAC0r4mrhkUNj5vcb3rIrKFAKbepOWLD8CfKbHQ+ui4CHPFOHxGzBXMmYJ58PqjA3yZIOOQ/Has4ZadNXaO0+WgBt+G0owv4/8v5U38dGXDW9zrr8lzwbcBL+o=,iv:PT1cqzzdpTsc86DqcmnDmGMH5BePM/njPz0aLV/X5cw=,tag:54ps63a0TRJaRFtQHcFsuQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/databases/clickhouse-canary/app/backup.sops.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/backup.sops.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zerocut-canary-backup-s3
+  namespace: databases
+type: Opaque
+stringData:
+  access_key: ENC[AES256_GCM,data:VoBSN2B0Ie0YtFunM6F1S7dPHft70PcUDswIXfJyF94=,iv:h5WRM1NSu5VmMOfd9v3ijbh5dnLDamyyL+4NajWdtYc=,tag:uhf9BDd4FT9l/GgeUQfF3g==,type:str]
+  secret_key: ENC[AES256_GCM,data:QGAINwpsr2IOdPnyxllmKWNFV5c3lK34pU8KpV+quKG5Uz03O//cOtKmCU3HXXsGhuJUJPXBY8e3w99c8H44sg==,iv:t4NoAHwCbhjS3zZmMjUpOqniO4nJchY5GsTKV/p9KQk=,tag:Fbh1d0OYIkpE+v+Hj+zF4Q==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2eFNBZlExd0w1ZDRxMmJl
+        Y3hBSjVQWHZQNm9mZXdCZ0E3aWFlSjB0QW5vCm9oTkgxUU14OXluallVSWEvcWtU
+        UmUrdWtFV1UzMmcva3I5NmpmUEhvYncKLS0tIHphanpWWlNnZjhiLzl5OTBMRkNl
+        NkJOK3RjbDBmekRSTlVLdTlxVGZOVHMK++Sj1SWUD9bWIJrVuMlEFSURmzHV+O5P
+        8Qme3Rce33c6MPzen/nBeZ0wVsiNMlSzNq/GU5s2brxphbjvTPWpjg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-25T09:16:37Z"
+  mac: ENC[AES256_GCM,data:Ai5wV9ZfYorEbN9nAg/enhXzyO4effMW5i1ybERKYLLsfxUM9hZM4NrT9Hbq2LnWW1pF4zNBFvggRl8D5uPnDqIjj65blKpTSPZiQZ0vaSn9vwLrvLZVvAvd9BvF06PAa/E/UV7/Ulu0qnq3/1VYvDQj75bL03uvZl0Z4PnIs3Y=,iv:AKqkL5ah98qSHQLSqEXGQzimuPP2tqHl7hcxK7CUudg=,tag:wBw7h/g4nj9aISgniWIb4g==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/databases/clickhouse-canary/app/clickhouse.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/clickhouse.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: zerocut-canary
+spec:
+  defaults:
+    storageManagement:
+      provisioner: Operator
+      reclaimPolicy: Retain
+    templates:
+      podTemplate: clickhouse
+      dataVolumeClaimTemplate: clickhouse-data
+      serviceTemplate: clickhouse-service
+  configuration:
+    zookeeper:
+      keeper:
+        name: zerocut-canary-keeper
+        namespace: databases
+      session_timeout_ms: 30000
+      operation_timeout_ms: 10000
+    settings:
+      prometheus/endpoint: /metrics
+      prometheus/port: "9363"
+      prometheus/metrics: "true"
+      prometheus/events: "true"
+      prometheus/asynchronous_metrics: "true"
+      prometheus/status_info: "true"
+    users:
+      zerocut_canary/password_sha256_hex:
+        valueFrom:
+          secretKeyRef:
+            name: zerocut-canary-credentials
+            key: password_sha256_hex
+      zerocut_canary/networks/ip:
+        - 10.42.0.0/16
+      zerocut_canary/profile: default
+      zerocut_canary/quota: default
+      zerocut_canary/named_collection_control: 1
+      zerocut_canary/grants/query:
+        - GRANT CREATE,ALTER,DROP,TRUNCATE,SELECT,INSERT,SHOW,dictGet,REMOTE ON *.*
+      zerocut_canary_backup/password_sha256_hex:
+        valueFrom:
+          secretKeyRef:
+            name: zerocut-canary-backup-user
+            key: password_sha256_hex
+      zerocut_canary_backup/networks/ip:
+        - 127.0.0.1
+      zerocut_canary_backup/profile: default
+      zerocut_canary_backup/quota: default
+      zerocut_canary_backup/grants/query:
+        - GRANT SELECT ON system.*
+        - GRANT ALTER FREEZE PARTITION,ALTER FETCH PARTITION,CREATE TABLE,DROP TABLE,CREATE DATABASE,DROP DATABASE,INSERT,SHOW ON *.*
+    clusters:
+      - name: zerocut
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+  templates:
+    podTemplates:
+      - name: clickhouse
+        metadata:
+          labels:
+            app.kubernetes.io/name: zerocut-canary-clickhouse
+        spec:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 101
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:26.3@sha256:8a47d18f8de3fbe12e7556ec3c72200ef47ff1c112958b4cb3ca083459cd3003
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 1Gi
+                limits:
+                  cpu: 2
+                  memory: 4Gi
+              volumeMounts:
+                - name: clickhouse-data
+                  mountPath: /var/lib/clickhouse
+            - name: clickhouse-backup
+              image: altinity/clickhouse-backup:2.8.0@sha256:d830170d635a3afa1568e13e81dd8194eac954195941b9554f15440cf6bc6c1b
+              imagePullPolicy: IfNotPresent
+              args:
+                - server
+                - --watch
+              env:
+                - name: TZ
+                  value: UTC
+                - name: LOG_LEVEL
+                  value: info
+                - name: CLICKHOUSE_HOST
+                  value: 127.0.0.1
+                - name: CLICKHOUSE_PORT
+                  value: "9000"
+                - name: CLICKHOUSE_USERNAME
+                  value: zerocut_canary_backup
+                - name: CLICKHOUSE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: zerocut-canary-backup-user
+                      key: password
+                - name: REMOTE_STORAGE
+                  value: s3
+                - name: S3_ENDPOINT
+                  value: https://s3.davidapps.dev
+                - name: S3_BUCKET
+                  value: clickhouse-zerocut-canary-backups
+                - name: S3_PATH
+                  value: zerocut-canary/shard-{shard}
+                - name: S3_REGION
+                  value: us-east-1
+                - name: S3_FORCE_PATH_STYLE
+                  value: "true"
+                - name: S3_DISABLE_SSL
+                  value: "false"
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: zerocut-canary-backup-s3
+                      key: access_key
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: zerocut-canary-backup-s3
+                      key: secret_key
+                - name: ALLOW_EMPTY_BACKUPS
+                  value: "true"
+                - name: BACKUPS_TO_KEEP_LOCAL
+                  value: "1"
+                - name: BACKUPS_TO_KEEP_REMOTE
+                  value: "32"
+                - name: REBASE_BEFORE_REMOVE_OLD_REMOTE
+                  value: "true"
+                - name: SHARDED_OPERATION_MODE
+                  value: first-replica
+                - name: WATCH_SCHEDULES
+                  value: name=canary,full=0 1 * * 0,increment=0 */6 * * *
+                - name: WATCH_BACKUP_NAME_TEMPLATE
+                  value: shard{shard}-{type}-{time:20060102T150405Z}
+                - name: API_LISTEN
+                  value: 0.0.0.0:7171
+                - name: API_ENABLE_METRICS
+                  value: "true"
+                - name: API_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: zerocut-canary-backup-api
+                      key: username
+                - name: API_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: zerocut-canary-backup-api
+                      key: password
+              ports:
+                - name: backup-rest
+                  containerPort: 7171
+                  protocol: TCP
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 101
+                runAsNonRoot: true
+                runAsUser: 101
+              volumeMounts:
+                - name: clickhouse-data
+                  mountPath: /var/lib/clickhouse
+    volumeClaimTemplates:
+      - name: clickhouse-data
+        provisioner: Operator
+        reclaimPolicy: Retain
+        spec:
+          storageClassName: openebs-hostpath
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+    serviceTemplates:
+      - name: clickhouse-service
+        generateName: clickhouse-zerocut-canary
+        spec:
+          ports:
+            - name: http
+              port: 8123
+            - name: tcp
+              port: 9000
+            - name: interserver
+              port: 9009
+            - name: metrics
+              port: 9363
+          type: ClusterIP

--- a/kubernetes/apps/databases/clickhouse-canary/app/credentials.sops.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/credentials.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zerocut-canary-credentials
+  namespace: databases
+type: Opaque
+stringData:
+  username: ENC[AES256_GCM,data:a9Ia9y/BGHe5B9H4lvE=,iv:NLJGHAi9p7Q6nOPV+Q6b5jnjjtAKMxYdZwPJluiBmgs=,tag:NTMj9EfRoNQFKUa6EE5dIg==,type:str]
+  password: ENC[AES256_GCM,data:uAzLMxeIVkV9ew2D2S5vT7jxup/b/Re6jFnd5xHjvWu34bE+R45sUvB7/N4s1hQN,iv:pWlIuN3Ea2HweCTp53QzmgL00ftUDXPWWrRHOFOFEbQ=,tag:HTHIpt6+9VfStmQWPXgHcw==,type:str]
+  password_sha256_hex: ENC[AES256_GCM,data:mqYrt/bT6mOm6qjcnwn2l92imKuFPf7Wxscip25rAjVw2SMY7TkXA6a4uSBxqfxVf2IHZ8JG4fGtkIStP/0WXA==,iv:6vpiFrRXQtfwxLKUSpHIxut5FdjWjiR5TjFjGe38S04=,tag:tJaY49Fazn44m22Xd4SYaA==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0YVBnWHZYSDU1WjdHWGlw
+        M0s3anhjeFA1bStLZ2lMNlNNL3ozZ0VMdVhvClZEdG92dHJ0ZjNFYUNtWjJJTU9n
+        MThYMjV5WnZ3MGVZMXA1clA5TWJTc2MKLS0tIG1LK0t5VmtNY2hvaFoxTUhDQ1JV
+        TTdRWEU4QTVmaCsvTFEwMjh3akFGNUUKkCmliEqZjhR+M5An+BZJPJB+OJdeVRK+
+        D25aMmV7eJCqhbqZtFUWIE62mWDADG5NTnf2U6GeDV7mzjns+a2Z7A==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-25T08:44:46Z"
+  mac: ENC[AES256_GCM,data:sZwPaMto2veICybH+D2AEXSPyy97tDlaHOTpgp0yvrL6bMf8S3LmQ8dU+J6Y1bRuv3YUGWQw5kGJjcKa9qhP3w8vuxCMnpeLMxXhJEe+xzuxtMtgfCSFoLn4aVMr/DAbJ6vzViM7Lq3QSOCyCY3QrwuNcvk9oR05tcvBiZDilQI=,iv:YLzSf3U4YProJrqCGY1WHqIIRmluWTzKuUyB8Slc7cE=,tag:XP5/8fymHLMtLZb/TKoJJg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/databases/clickhouse-canary/app/keeper.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/keeper.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: clickhouse-keeper.altinity.com/v1
+kind: ClickHouseKeeperInstallation
+metadata:
+  name: zerocut-canary-keeper
+spec:
+  defaults:
+    storageManagement:
+      provisioner: Operator
+      reclaimPolicy: Retain
+    templates:
+      podTemplate: keeper
+      dataVolumeClaimTemplate: keeper-data
+      serviceTemplate: keeper-service
+  configuration:
+    settings:
+      logger/level: information
+      logger/console: "true"
+      listen_host: 0.0.0.0
+      keeper_server/four_letter_word_white_list: ruok,conf,stat,mntr
+      keeper_server/coordination_settings/raft_logs_level: information
+      prometheus/endpoint: /metrics
+      prometheus/port: "7000"
+      prometheus/metrics: "true"
+      prometheus/events: "true"
+      prometheus/asynchronous_metrics: "true"
+    clusters:
+      - name: keeper
+        pdbManaged: "true"
+        pdbMaxUnavailable: 0
+        layout:
+          replicasCount: 1
+  templates:
+    podTemplates:
+      - name: keeper
+        metadata:
+          labels:
+            app.kubernetes.io/name: zerocut-canary-keeper
+        spec:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 101
+          containers:
+            - name: clickhouse-keeper
+              image: clickhouse/clickhouse-keeper:26.3@sha256:0c9b657f579aff6957e819748cd79cebd2f3b6bcc03a129abc645700dcf35aae
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+              volumeMounts:
+                - name: keeper-data
+                  mountPath: /var/lib/clickhouse-keeper
+    volumeClaimTemplates:
+      - name: keeper-data
+        provisioner: Operator
+        reclaimPolicy: Retain
+        spec:
+          storageClassName: openebs-hostpath
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 2Gi
+    serviceTemplates:
+      - name: keeper-service
+        generateName: keeper-zerocut-canary
+        spec:
+          ports:
+            - name: zk
+              port: 2181
+            - name: raft
+              port: 9444
+            - name: prometheus
+              port: 7000
+          type: ClusterIP

--- a/kubernetes/apps/databases/clickhouse-canary/app/kustomization.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: databases
+resources:
+  - ./backup-api.sops.yaml
+  - ./backup-user.sops.yaml
+  - ./backup.sops.yaml
+  - ./credentials.sops.yaml
+  - ./keeper.yaml
+  - ./clickhouse.yaml
+  - ./networkpolicy.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/databases/clickhouse-canary/app/networkpolicy.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/networkpolicy.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zerocut-canary-clickhouse
+spec:
+  podSelector:
+    matchLabels:
+      clickhouse.altinity.com/chi: zerocut-canary
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 8123
+          protocol: TCP
+        - port: 9000
+          protocol: TCP
+        - port: 9009
+          protocol: TCP
+        - port: 9363
+          protocol: TCP
+        - port: 7171
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 7000
+          protocol: TCP
+        - port: 9363
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector: {}
+      ports:
+        - port: 2181
+          protocol: TCP
+        - port: 8123
+          protocol: TCP
+        - port: 9000
+          protocol: TCP
+        - port: 9009
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 192.168.100.102/32
+      ports:
+        - port: 443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zerocut-canary-keeper
+spec:
+  podSelector:
+    matchLabels:
+      clickhouse-keeper.altinity.com/chk: zerocut-canary-keeper
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 2181
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+        - port: 9444
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - port: 7000
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector: {}
+      ports:
+        - port: 2181
+          protocol: TCP
+        - port: 9444
+          protocol: TCP

--- a/kubernetes/apps/databases/clickhouse-canary/app/podmonitor.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/podmonitor.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: zerocut-clickhouse-canary
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      clickhouse.altinity.com/chi: zerocut-canary
+  podTargetLabels:
+    - clickhouse.altinity.com/shard
+    - clickhouse.altinity.com/replica
+  podMetricsEndpoints:
+    - targetPort: 9363
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+    - port: backup-rest
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      basicAuth:
+        username:
+          name: zerocut-canary-backup-api
+          key: username
+        password:
+          name: zerocut-canary-backup-api
+          key: password

--- a/kubernetes/apps/databases/clickhouse-canary/ks.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse-canary
+  namespace: &namespace databases
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: altinity-clickhouse-operator
+      namespace: databases
+  interval: 30m
+  retryInterval: 1m
+  path: ./kubernetes/apps/databases/clickhouse-canary/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 20m
+  wait: true

--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: databases
 resources:
+  - ./altinity-clickhouse-operator/ks.yaml
+  - ./clickhouse-canary/ks.yaml
   - ./cloudnative-pg/ks.yaml
   - ./dragonfly/ks.yaml
   - ./clickhouse/ks.yaml

--- a/kubernetes/apps/observability/grafana/app/dashboards/clickhouse-instances.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/clickhouse-instances.json
@@ -47,7 +47,7 @@
   "templating": {
     "list": [
       {
-        "allValue": "clickhouse|plausible-clickhouse",
+        "allValue": "clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse",
         "current": {
           "selected": true,
           "text": [
@@ -61,7 +61,7 @@
           "type": "prometheus",
           "uid": "prometheus-home-cluster"
         },
-        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"clickhouse|plausible-clickhouse\"}, job)",
+        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse\"}, job)",
         "description": "ClickHouse ServiceMonitor scrape job.",
         "hide": 0,
         "includeAll": true,
@@ -70,12 +70,45 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"clickhouse|plausible-clickhouse\"}, job)",
+          "query": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse\"}, job)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus-home-cluster"
+        },
+        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"${instance:regex}\"}, pod)",
+        "description": "Pods belonging to the selected ClickHouse scrape jobs.",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"${instance:regex}\"}, pod)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
         "sort": 1,
         "type": "query"
       }
@@ -622,7 +655,7 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\",container=\"app\"}[$__range]))",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__range]))",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -1853,7 +1886,7 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (container_memory_working_set_bytes{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\",container=\"app\"})",
+          "expr": "sum by (namespace, pod) (container_memory_working_set_bytes{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"})",
           "legendFormat": "{{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -1916,7 +1949,7 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\",container=\"app\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__rate_interval]))",
           "legendFormat": "{{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -1979,7 +2012,7 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_network_receive_bytes_total{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_network_receive_bytes_total{pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "receive \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -1991,7 +2024,7 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_network_transmit_bytes_total{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_network_transmit_bytes_total{pod=~\"${pod:regex}\"}[$__rate_interval]))",
           "legendFormat": "transmit \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -2054,7 +2087,7 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_fs_reads_bytes_total{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\",container=\"app\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_fs_reads_bytes_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__rate_interval]))",
           "legendFormat": "read \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -2066,13 +2099,294 @@
             "uid": "prometheus-home-cluster"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_fs_writes_bytes_total{namespace=~\"databases|observability\",pod=~\"(${instance:regex})-.*\",container=\"app\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_fs_writes_bytes_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__rate_interval]))",
           "legendFormat": "write \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
           "refId": "B"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "id": 45,
+      "panels": [],
+      "title": "Recovery backups",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-home-cluster"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 28800
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 91
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-home-cluster"
+          },
+          "editorMode": "code",
+          "expr": "time() - (clickhouse_backup_last_create_remote_finish{job=~\"${instance:regex}\",clickhouse_altinity_com_replica=\"0\"} > 0)",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Remote backup age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-home-cluster"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Failed"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Succeeded"
+                },
+                "2": {
+                  "color": "yellow",
+                  "text": "Not run"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 91
+      },
+      "id": 47,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-home-cluster"
+          },
+          "editorMode": "code",
+          "expr": "clickhouse_backup_last_create_remote_status{job=~\"${instance:regex}\",clickhouse_altinity_com_replica=\"0\"}",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Last remote backup",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-home-cluster"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 91
+      },
+      "id": 48,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-home-cluster"
+          },
+          "editorMode": "code",
+          "expr": "clickhouse_backup_number_backups_remote{job=~\"${instance:regex}\",clickhouse_altinity_com_replica=\"0\"}",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Remote backups retained",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-home-cluster"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 91
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-home-cluster"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(clickhouse_backup_failed_create_remotes{job=~\"${instance:regex}\"}[$__range])) + sum(increase(clickhouse_backup_failed_parts_count{job=~\"${instance:regex}\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Backup failures in range",
+      "type": "stat"
     }
   ]
 }

--- a/kubernetes/flux/meta/repositories/helm/altinity.yaml
+++ b/kubernetes/flux/meta/repositories/helm/altinity.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: altinity
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://helm.altinity.com

--- a/kubernetes/flux/meta/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/helm/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./altinity.yaml
   - ./cilium.yaml
   - ./external-dns.yaml
   - ./ingress-nginx.yaml


### PR DESCRIPTION
## Summary
- install Altinity ClickHouse Operator 0.27.3 with digest-pinned operator images
- add an isolated 1x1 ClickHouse 26.3 + Keeper canary with retained PVCs
- add encrypted backup credentials, six-hour incrementals, weekly full backups, authenticated metrics, and network policy
- extend the existing ClickHouse dashboard for operator-managed pods and recovery backup status

## Verification
- kustomize builds pass for the operator, canary, databases, and Helm repositories
- strict kubeconform passes against Altinity 0.27.3 and live Flux/Prometheus CRD schemas
- all SOPS manifests report encrypted and use the home-cluster recipient
- all 43 dashboard PromQL expressions pass promtool
- operator Helm render uses the pinned image digests

## Deployment and rollback
Merge deploys only the isolated canary; it does not touch the existing ZeroCut source ClickHouse. Verify pod/PVC readiness, remote backup + mapped restore, metrics, retained-PVC behavior, and operator lifecycle before advancing the production target. Rollback is Git revert; PVC reclaim policy is Retain.