### PR TITLE
fix(clickhouse): make canary grants loadable

### DIFF
--- a/kubernetes/apps/databases/clickhouse-canary/app/clickhouse.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/clickhouse.yaml
@@ -36,7 +36,6 @@ spec:
         - 10.42.0.0/16
       zerocut_canary/profile: default
       zerocut_canary/quota: default
-      zerocut_canary/named_collection_control: 1
       zerocut_canary/grants/query:
         - GRANT CREATE,ALTER,DROP,TRUNCATE,SELECT,INSERT,SHOW,dictGet,REMOTE ON *.*
       zerocut_canary_backup/password_sha256_hex:


### PR DESCRIPTION
Fix the ClickHouse 26.3 startup failure found by the live Altinity canary.

`named_collection_control` cannot be combined with explicit `grants` in a configured user. The named collection flag is not required by the canary acceptance flow, so remove it while preserving the scoped grants, network restrictions, profile, and quota.

Live regression signal before this change: the ClickHouse container repeatedly exits with `BAD_ARGUMENTS` while parsing `zerocut_canary`. After merge, the same canary will be reconciled and must start cleanly before remote backup/restore acceptance.