### PR TITLE
fix(clickhouse): expose canary metrics

### DIFF
--- a/kubernetes/apps/databases/clickhouse-canary/app/clickhouse.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/clickhouse.yaml
@@ -71,6 +71,10 @@ spec:
             - name: clickhouse
               image: clickhouse/clickhouse-server:26.3@sha256:8a47d18f8de3fbe12e7556ec3c72200ef47ff1c112958b4cb3ca083459cd3003
               imagePullPolicy: IfNotPresent
+              ports:
+                - name: metrics
+                  containerPort: 9363
+                  protocol: TCP
               resources:
                 requests:
                   cpu: 250m

--- a/kubernetes/apps/databases/clickhouse-canary/app/networkpolicy.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/networkpolicy.yaml
@@ -33,6 +33,8 @@ spec:
           protocol: TCP
         - port: 9363
           protocol: TCP
+        - port: 7171
+          protocol: TCP
   egress:
     - to:
         - namespaceSelector:

--- a/kubernetes/apps/databases/clickhouse-canary/app/podmonitor.yaml
+++ b/kubernetes/apps/databases/clickhouse-canary/app/podmonitor.yaml
@@ -12,7 +12,7 @@ spec:
     - clickhouse.altinity.com/shard
     - clickhouse.altinity.com/replica
   podMetricsEndpoints:
-    - targetPort: 9363
+    - port: metrics
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s


### PR DESCRIPTION
Fix the two monitoring defects found during live canary acceptance.

- Declare ClickHouse port 9363 on the pod and select the named `metrics` port from the PodMonitor.
- Allow Prometheus in the `observability` namespace to reach the authenticated backup API on 7171.

Before this change, Prometheus omitted the ClickHouse target and reported a timeout for the backup target. After merge, acceptance requires both targets to report `up == 1`; the already-passing remote backup/restore remains intact.