### PR TITLE
feat(cliproxy): add public API hostname

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -248,7 +248,7 @@ spec:
             conditions: ["[STATUS] == 200"]
         hosts:
           - host: &host "cliproxy.davidhome.ro"
-            paths:
+            paths: &openApiPaths
               - path: /v1
                 service: &appService
                   identifier: app
@@ -264,8 +264,10 @@ spec:
               - path: /internal/employee-hub/v1/usage
                 pathType: Exact
                 service: *appService
+          - host: &apiHost "cliproxyapi.davidhome.ro"
+            paths: *openApiPaths
         tls:
-          - hosts: [*host]
+          - hosts: [*host, *apiHost]
       management:
         className: external
         annotations:


### PR DESCRIPTION
## Summary
- publish the requested `cliproxyapi.davidhome.ro` hostname for CLIProxy API routes
- keep the existing `cliproxy.davidhome.ro` hostname compatible
- include both names in ingress TLS and external-dns discovery

The management surface remains on the existing DavidApps-gated hostname; only API and health routes are aliased.

## Validation
- targeted Kustomize render passed
- kubeconform passed for all non-SOPS resources (10 valid, 0 invalid)
- git diff validation passed