### PR TITLE
fix(cliproxy): target the home ingress endpoint

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/davidapps-gate.yaml
+++ b/kubernetes/apps/default/cliproxy/app/davidapps-gate.yaml
@@ -28,7 +28,7 @@ kind: Ingress
 metadata:
   name: cliproxy-gate-start
   annotations:
-    external-dns.alpha.kubernetes.io/target: external.davidapps.dev
+    external-dns.alpha.kubernetes.io/target: external.davidhome.ro
     nginx.ingress.kubernetes.io/proxy-body-size: 4k
     nginx.ingress.kubernetes.io/client-body-buffer-size: 4k
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "5"
@@ -59,7 +59,7 @@ kind: Ingress
 metadata:
   name: cliproxy-gate-callback
   annotations:
-    external-dns.alpha.kubernetes.io/target: external.davidapps.dev
+    external-dns.alpha.kubernetes.io/target: external.davidhome.ro
     nginx.ingress.kubernetes.io/proxy-body-size: 4k
     nginx.ingress.kubernetes.io/client-body-buffer-size: 4k
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "5"
@@ -90,7 +90,7 @@ kind: Ingress
 metadata:
   name: cliproxy-gate-password
   annotations:
-    external-dns.alpha.kubernetes.io/target: external.davidapps.dev
+    external-dns.alpha.kubernetes.io/target: external.davidhome.ro
     nginx.ingress.kubernetes.io/proxy-body-size: 4k
     nginx.ingress.kubernetes.io/client-body-buffer-size: 4k
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "5"
@@ -121,7 +121,7 @@ kind: Ingress
 metadata:
   name: cliproxy-gate-redeem
   annotations:
-    external-dns.alpha.kubernetes.io/target: external.davidapps.dev
+    external-dns.alpha.kubernetes.io/target: external.davidhome.ro
     nginx.ingress.kubernetes.io/proxy-body-size: 4k
     nginx.ingress.kubernetes.io/client-body-buffer-size: 4k
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "5"
@@ -152,7 +152,7 @@ kind: Ingress
 metadata:
   name: cliproxy-gate-bypass
   annotations:
-    external-dns.alpha.kubernetes.io/target: external.davidapps.dev
+    external-dns.alpha.kubernetes.io/target: external.davidhome.ro
     nginx.ingress.kubernetes.io/proxy-body-size: 4k
     nginx.ingress.kubernetes.io/client-body-buffer-size: 4k
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "5"

--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -237,7 +237,7 @@ spec:
       open-api:
         className: external
         annotations:
-          external-dns.alpha.kubernetes.io/target: "external.davidapps.dev"
+          external-dns.alpha.kubernetes.io/target: "external.davidhome.ro"
           gethomepage.dev/enabled: "false"
           nginx.ingress.kubernetes.io/proxy-set-headers: auth/davidapps-empty-trusted-headers
           gatus.home-operations.com/endpoint: |-
@@ -271,7 +271,7 @@ spec:
       management:
         className: external
         annotations:
-          external-dns.alpha.kubernetes.io/target: "external.davidapps.dev"
+          external-dns.alpha.kubernetes.io/target: "external.davidhome.ro"
           nginx.ingress.kubernetes.io/auth-url: "http://davidapps-gate.auth.svc.cluster.local:8080/gate/check"
           nginx.ingress.kubernetes.io/auth-signin: "https://$host/_da/gate/start"
           nginx.ingress.kubernetes.io/auth-signin-redirect-param: rd


### PR DESCRIPTION
## What changed
- point CLIProxy public and management ingresses at `external.davidhome.ro`
- point the DavidApps gate callback ingresses at the same home-cluster endpoint

## Why
Employee Hub runs on davidapps-cluster. `cliproxy.davidhome.ro` was published as a CNAME to `external.davidapps.dev`, which resolves to davidapps-cluster (`192.168.100.102`) there. The request reached the wrong ingress and Node rejected its `*.davidapps.dev` certificate with `ERR_TLS_CERT_ALTNAME_INVALID`. `external.davidhome.ro` resolves to the home ingress (`192.168.100.92`).

The dedicated Employee Hub tokens already match, and the live CLIProxy endpoint returns HTTP 200 with its expected safe usage schema when reached through the home ingress.

## Verification
- `git diff --check`
- `pipx run --spec flux-local==8.4.0 flux-local test --enable-helm --all-namespaces --path kubernetes/flux/cluster -v` (208 passed)
- credentialed public endpoint: HTTP 200, JSON `data`, 8 profiles
- current in-pod reproduction: `ERR_TLS_CERT_ALTNAME_INVALID`, presented SAN `*.davidapps.dev`
