### PR TITLE
feat(plausible): add scoped Employee Hub site reader

### DIFF
--- a/kubernetes/apps/observability/plausible/app/employee-hub-reader-secret.sops.yaml
+++ b/kubernetes/apps/observability/plausible/app/employee-hub-reader-secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: plausible-employee-hub-reader-secret
+type: Opaque
+stringData:
+  PLAUSIBLE_READER_PASSWORD: ENC[AES256_GCM,data:TYsjfgZ+cYBY8bX1yn1WZA8jr/unIFxDaKMRV7LGQQOCF8P2coI8ptQwlQB5xmHPU1TZN/LPzCapr5RFfYQFrw==,iv:gnvLoE0PlyV5ATnLFk4jG9QPb+59lxkZ8mkkuv+tFhI=,tag:ZzPB72ppcONvTjiv17KvHA==,type:str]
+sops:
+  age:
+    - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1aVl0SnF4WUhKNXZJcGJ4
+        azVoRytWbmMvNk11OC9pSEI2dzhWTnN2Y1RvCnMyT281RkN0c2ZGbitxdlpMZDI3
+        UG9DekdtbTYwMlJOZHFrcDlKNXcrQ2sKLS0tIGdsZDZ2cXdvbjRYMnFKaUNkOWNE
+        a01naHdxV2ZuK29jOEpYTFpqNjFJSW8K9MXrslQj+bRGdL//p3/FgfGc00OttiV4
+        EV9FGDM0jSp8FME25mHZi0btUEWovfrfP2BIE1A9SqKQqPo7MmFXMA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-08-25T15:54:17Z"
+  mac: ENC[AES256_GCM,data:Qj/m0XgmSqAib2R/uo19U2qUYnS1BC6fTKZgxKN/GtzvyAxEQDIusLnJJbL8zNDwx3P8zJR9P+PbLSc+JdFUGt9oS58IuOZbPuTTcU3YU+Q4Qi1KVqoBvro0y2J7bA8Zk15oLy7xHew9pSmSmF7TMuEqyPDgYwS3Q2iWgtjpSF4=,iv:5+RVkcJnwa+G9QB7weMsJQe67IOOmJFslc9aCoLK6r4=,tag:OsqjYiD2zBtqDIqEFSF+0Q==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
+++ b/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
@@ -1,5 +1,7 @@
 \set ON_ERROR_STOP on
 
+BEGIN;
+
 SELECT 'CREATE ROLE employee_hub_plausible_owner NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS'
 WHERE NOT EXISTS (
   SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'employee_hub_plausible_owner'
@@ -19,6 +21,13 @@ WHERE NOT EXISTS (
 ALTER ROLE employee_hub_plausible_reader
   LOGIN PASSWORD :'reader_password'
   NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS;
+
+ALTER ROLE employee_hub_plausible_reader SET default_transaction_read_only TO true;
+ALTER ROLE employee_hub_plausible_reader SET statement_timeout TO '5s';
+ALTER ROLE employee_hub_plausible_reader SET lock_timeout TO '2s';
+ALTER ROLE employee_hub_plausible_reader SET idle_in_transaction_session_timeout TO '5s';
+ALTER ROLE employee_hub_plausible_reader SET search_path TO pg_catalog;
+ALTER ROLE employee_hub_plausible_reader SET temp_file_limit TO '16MB';
 
 SELECT format('REVOKE %I FROM employee_hub_plausible_owner', granted_role.rolname)
 FROM pg_catalog.pg_auth_members AS membership
@@ -88,7 +97,7 @@ BEGIN
         'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
       )
   ) THEN
-    RAISE EXCEPTION 'Employee Hub reader has direct public relation access';
+    RAISE EXCEPTION 'Employee Hub reader has effective public relation access';
   END IF;
 
   IF EXISTS (
@@ -105,7 +114,78 @@ BEGIN
         ELSE false
       END
   ) THEN
-    RAISE EXCEPTION 'Employee Hub reader has direct public sequence access';
+    RAISE EXCEPTION 'Employee Hub reader has effective public sequence access';
+  END IF;
+
+  IF pg_catalog.has_schema_privilege(
+    'employee_hub_plausible_reader',
+    'public',
+    'CREATE'
+  ) OR pg_catalog.has_schema_privilege(
+    'employee_hub_plausible_reader',
+    'employee_hub',
+    'CREATE'
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader can create durable schema objects';
+  END IF;
+
+  IF pg_catalog.has_schema_privilege(
+    'employee_hub_plausible_owner',
+    'public',
+    'CREATE'
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub function owner can create objects in public';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_proc AS function
+    WHERE function.prosecdef
+      AND function.oid <> 'employee_hub.list_sites()'::pg_catalog.regprocedure
+      AND pg_catalog.has_function_privilege(
+        'employee_hub_plausible_reader',
+        function.oid,
+        'EXECUTE'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader can execute an unexpected SECURITY DEFINER function';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_auth_members AS membership
+    JOIN pg_catalog.pg_roles AS member_role ON member_role.oid = membership.member
+    WHERE member_role.rolname IN (
+      'employee_hub_plausible_owner',
+      'employee_hub_plausible_reader'
+    )
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub database roles retain inherited memberships';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_roles AS reader
+    WHERE reader.rolname = 'employee_hub_plausible_reader'
+      AND (
+        EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspowner = reader.oid)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_class WHERE relowner = reader.oid)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_proc WHERE proowner = reader.oid)
+        OR EXISTS (SELECT 1 FROM pg_catalog.pg_type WHERE typowner = reader.oid)
+      )
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader owns database objects';
+  END IF;
+
+  -- The shared database grants CONNECT and TEMPORARY to PUBLIC. TEMPORARY is
+  -- session-local; durable data remains protected by the effective relation
+  -- checks above, default read-only transactions, and the SECURITY DEFINER audit.
+  IF NOT pg_catalog.has_database_privilege(
+    'employee_hub_plausible_reader',
+    pg_catalog.current_database(),
+    'CONNECT'
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader cannot connect to the Plausible database';
   END IF;
 
   IF NOT pg_catalog.has_function_privilege(
@@ -117,3 +197,5 @@ BEGIN
   END IF;
 END
 $check$;
+
+COMMIT;

--- a/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
+++ b/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
@@ -1,0 +1,105 @@
+\set ON_ERROR_STOP on
+
+SELECT 'CREATE ROLE employee_hub_plausible_owner NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS'
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'employee_hub_plausible_owner'
+) \gexec
+
+ALTER ROLE employee_hub_plausible_owner
+  NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS;
+
+SELECT format(
+  'CREATE ROLE employee_hub_plausible_reader LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS',
+  :'reader_password'
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'employee_hub_plausible_reader'
+) \gexec
+
+ALTER ROLE employee_hub_plausible_reader
+  LOGIN PASSWORD :'reader_password'
+  NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
+
+CREATE SCHEMA IF NOT EXISTS employee_hub AUTHORIZATION employee_hub_plausible_owner;
+ALTER SCHEMA employee_hub OWNER TO employee_hub_plausible_owner;
+REVOKE ALL ON SCHEMA employee_hub FROM PUBLIC;
+GRANT USAGE ON SCHEMA employee_hub TO employee_hub_plausible_reader;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM employee_hub_plausible_reader;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM employee_hub_plausible_reader;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA public FROM employee_hub_plausible_reader;
+REVOKE ALL ON ALL PROCEDURES IN SCHEMA public FROM employee_hub_plausible_reader;
+
+GRANT USAGE ON SCHEMA public TO employee_hub_plausible_owner;
+GRANT SELECT (domain, team_id) ON TABLE public.sites TO employee_hub_plausible_owner;
+GRANT SELECT (id, identifier) ON TABLE public.teams TO employee_hub_plausible_owner;
+
+CREATE OR REPLACE FUNCTION employee_hub.list_sites()
+RETURNS TABLE(domain text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $function$
+  SELECT s.domain::pg_catalog.text
+  FROM public.sites AS s
+  JOIN public.teams AS t ON t.id = s.team_id
+  WHERE t.identifier = 'a4ef2a8b-e3be-4b65-b1aa-601352802d01'::pg_catalog.uuid
+  ORDER BY pg_catalog.lower(s.domain::pg_catalog.text), s.domain
+$function$;
+
+ALTER FUNCTION employee_hub.list_sites() OWNER TO employee_hub_plausible_owner;
+REVOKE ALL ON FUNCTION employee_hub.list_sites() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION employee_hub.list_sites() TO employee_hub_plausible_reader;
+
+DO $check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.teams
+    WHERE identifier = 'a4ef2a8b-e3be-4b65-b1aa-601352802d01'::pg_catalog.uuid
+  ) THEN
+    RAISE EXCEPTION 'Bostan Enterprise Plausible team does not exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_class AS relation
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND relation.relkind IN ('r', 'p', 'v', 'm', 'f')
+      AND pg_catalog.has_table_privilege(
+        'employee_hub_plausible_reader',
+        relation.oid,
+        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader has direct public relation access';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_class AS sequence
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = sequence.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND CASE
+        WHEN sequence.relkind = 'S' THEN pg_catalog.has_sequence_privilege(
+          'employee_hub_plausible_reader',
+          sequence.oid,
+          'SELECT,UPDATE,USAGE'
+        )
+        ELSE false
+      END
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader has direct public sequence access';
+  END IF;
+
+  IF NOT pg_catalog.has_function_privilege(
+    'employee_hub_plausible_reader',
+    'employee_hub.list_sites()',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'Employee Hub reader cannot execute list_sites()';
+  END IF;
+END
+$check$;

--- a/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
+++ b/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
@@ -1,4 +1,11 @@
 \set ON_ERROR_STOP on
+\getenv reader_password PLAUSIBLE_READER_PASSWORD
+
+\if :{?reader_password}
+\else
+  \echo 'PLAUSIBLE_READER_PASSWORD is required'
+  SELECT 1 / 0;
+\endif
 
 BEGIN;
 

--- a/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
+++ b/kubernetes/apps/observability/plausible/app/employee-hub-reader.sql
@@ -9,7 +9,7 @@ ALTER ROLE employee_hub_plausible_owner
   NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS;
 
 SELECT format(
-  'CREATE ROLE employee_hub_plausible_reader LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS',
+  'CREATE ROLE employee_hub_plausible_reader LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS',
   :'reader_password'
 )
 WHERE NOT EXISTS (
@@ -18,7 +18,21 @@ WHERE NOT EXISTS (
 
 ALTER ROLE employee_hub_plausible_reader
   LOGIN PASSWORD :'reader_password'
-  NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
+  NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS;
+
+SELECT format('REVOKE %I FROM employee_hub_plausible_owner', granted_role.rolname)
+FROM pg_catalog.pg_auth_members AS membership
+JOIN pg_catalog.pg_roles AS granted_role ON granted_role.oid = membership.roleid
+JOIN pg_catalog.pg_roles AS member_role ON member_role.oid = membership.member
+WHERE member_role.rolname = 'employee_hub_plausible_owner'
+\gexec
+
+SELECT format('REVOKE %I FROM employee_hub_plausible_reader', granted_role.rolname)
+FROM pg_catalog.pg_auth_members AS membership
+JOIN pg_catalog.pg_roles AS granted_role ON granted_role.oid = membership.roleid
+JOIN pg_catalog.pg_roles AS member_role ON member_role.oid = membership.member
+WHERE member_role.rolname = 'employee_hub_plausible_reader'
+\gexec
 
 CREATE SCHEMA IF NOT EXISTS employee_hub AUTHORIZATION employee_hub_plausible_owner;
 ALTER SCHEMA employee_hub OWNER TO employee_hub_plausible_owner;

--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -36,10 +36,7 @@ spec:
             args:
               - |
                 export PGDATABASE="$DATABASE_URL"
-                {
-                  printf '\set reader_password %s\n' "$PLAUSIBLE_READER_PASSWORD"
-                  cat /bootstrap/employee-hub-reader.sql
-                } | psql --variable=ON_ERROR_STOP=1
+                psql --variable=ON_ERROR_STOP=1 --file=/bootstrap/employee-hub-reader.sql
             env:
               DATABASE_URL:
                 valueFrom:

--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -25,7 +25,42 @@ spec:
           # existed, so reloader silently never restarted this Deployment on a
           # credential change. The Secret actually consumed via envFrom below
           # is `plausible-secret`.
-          secret.reloader.stakater.com/reload: plausible-secret
+          secret.reloader.stakater.com/reload: plausible-secret,plausible-employee-hub-reader-secret
+          configmap.reloader.stakater.com/reload: plausible-employee-hub-reader-sql
+        initContainers:
+          employee-hub-reader:
+            image:
+              repository: ghcr.io/cloudnative-pg/postgresql
+              tag: 17.2-32@sha256:b17d21f8ec36add9b3c0ea3fb354d05f62a8fddf8ba65ae94e63ba77bc42202e
+            command: ["sh", "-ec"]
+            args:
+              - |
+                export PGDATABASE="$DATABASE_URL"
+                {
+                  printf '\set reader_password %s\n' "$PLAUSIBLE_READER_PASSWORD"
+                  cat /bootstrap/employee-hub-reader.sql
+                } | psql --variable=ON_ERROR_STOP=1
+            env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: plausible-secret
+                    key: DATABASE_URL
+              PLAUSIBLE_READER_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: plausible-employee-hub-reader-secret
+                    key: PLAUSIBLE_READER_PASSWORD
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
         containers:
           app:
             image:
@@ -74,6 +109,15 @@ spec:
             supplementalGroups: [10000]
             seccompProfile: { type: RuntimeDefault }
     persistence:
+      employee-hub-reader-sql:
+        type: configMap
+        name: plausible-employee-hub-reader-sql
+        advancedMounts:
+          plausible:
+            employee-hub-reader:
+              - path: /bootstrap/employee-hub-reader.sql
+                subPath: employee-hub-reader.sql
+                readOnly: true
       tmp:
         enabled: true
         type: emptyDir

--- a/kubernetes/apps/observability/plausible/app/kustomization.yaml
+++ b/kubernetes/apps/observability/plausible/app/kustomization.yaml
@@ -4,4 +4,13 @@ kind: Kustomization
 namespace: default
 resources:
   - ./secret.sops.yaml
+  - ./employee-hub-reader-secret.sops.yaml
   - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: plausible-employee-hub-reader-sql
+    files:
+      - employee-hub-reader.sql
+
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
## What changed
- add atomic, idempotent PostgreSQL provisioning for a dedicated `employee_hub_plausible_reader` login
- expose `employee_hub.list_sites() RETURNS TABLE(domain text)`
- fix the function to Bostan Enterprise team `a4ef2a8b-e3be-4b65-b1aa-601352802d01`
- keep column privileges on a separate NOLOGIN function owner
- rotate the reader password through SOPS and rerun provisioning when its secret or SQL changes

## Least-privilege properties
- reader is `NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS` with default read-only transactions and short statement, lock, and idle-transaction timeouts
- provisioning removes all inherited role memberships and rejects any objects owned by the reader
- effective privilege checks include direct, inherited, and `PUBLIC` grants; provisioning rejects any public relation or sequence access
- reader and function owner cannot create objects in `public`; reader also cannot create objects in `employee_hub`
- reader receives explicit schema usage and execute grants only for `employee_hub.list_sites()`
- function uses `SECURITY DEFINER`, a fixed UUID, fully qualified relations, and `search_path = pg_catalog`
- provisioning rejects any other SECURITY DEFINER function executable by the reader
- provisioning runs inside `BEGIN`/`COMMIT`, so a failed invariant rolls back roles, schema, function, and grants together

PostgreSQL grants `CONNECT` and `TEMPORARY` on this shared database through `PUBLIC`; the live audit confirmed both. `TEMPORARY` is session-local. Public extension helper functions are security-invoker, and the reader has no effective relation privileges. The SQL invariant rejects any future executable SECURITY DEFINER helper. The NOLOGIN function owner owns only the dedicated schema/function and cannot create public objects.

## Verification
- ran the provisioning body twice inside one live Plausible PostgreSQL transaction
- switched to the reader role and called `SELECT count(*) FROM employee_hub.list_sites()`; result was 3
- injected a forced failure before commit; process failed and zero reader roles/schema remained
- rolled back all successful tests; confirmed zero roles and zero `employee_hub` schemas persisted
- Flux Local full suite: 208 passed
- current targeted Flux Local checks: Plausible Kustomization and HelmRelease passed
- Kustomize build, SOPS encrypted status, and `git diff --check` passed

No credentials are present in plaintext.