### PR TITLE
fix(plausible): run Employee Hub reader bootstrap as image user

### DIFF
--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -56,6 +56,9 @@ spec:
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false
+              runAsUser: 26
+              runAsGroup: 26
+              runAsNonRoot: true
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
         containers:


### PR DESCRIPTION
## Summary
- run the Employee Hub Plausible reader init container as the pinned PostgreSQL image non-root user
- preserve the existing read-only filesystem, dropped capabilities, and no-escalation controls

## Production evidence
The first rollout inherited Plausible pod UID/GID 568, but the pinned PostgreSQL client image defines `postgres` as UID/GID 26. The init failed before connecting with `local user with ID 568 does not exist`; the previous Plausible replica remained available.

## Validation
- `kubectl kustomize kubernetes/apps/observability/plausible/app`
- `git diff --check`
- live image identity confirmed as UID/GID 26 from the running pinned PostgreSQL image

After merge I will reconcile and verify the init exits 0 before advancing Employee Hub infrastructure.