### PR TITLE
Add ZeroCut ClickHouse operations dashboards

### DIFF
--- a/hack/generate-application-dashboards.py
+++ b/hack/generate-application-dashboards.py
@@ -21,6 +21,7 @@ DASHBOARDS = ROOT / "kubernetes/apps/observability/grafana/app/dashboards"
 PROM = {"type": "prometheus", "uid": "prometheus-davidapps-cluster"}
 SPAN_PROM = {"type": "prometheus", "uid": "prometheus-home-cluster"}
 KUBE_PROM = {"type": "prometheus", "uid": "prometheus-kube-stack"}
+CLICKHOUSE_PROM = {"type": "prometheus", "uid": "${datasource}"}
 VLOGS = {"type": "victoriametrics-logs-datasource", "uid": "victoria-logs"}
 
 APP = "${application:regex}"
@@ -212,12 +213,12 @@ def application_variable() -> dict:
 def clickhouse_variable() -> dict:
     query = (
         'label_values(ClickHouseAsyncMetrics_Uptime{'
-        'job=~"clickhouse|plausible-clickhouse"}, job)'
+        'job=~"clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse"}, job)'
     )
     return {
-        "allValue": "clickhouse|plausible-clickhouse",
+        "allValue": "clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse",
         "current": {"selected": True, "text": ["All"], "value": ["$__all"]},
-        "datasource": copy.deepcopy(KUBE_PROM),
+        "datasource": copy.deepcopy(CLICKHOUSE_PROM),
         "definition": query,
         "description": "ClickHouse ServiceMonitor scrape job.",
         "hide": 0,
@@ -233,6 +234,39 @@ def clickhouse_variable() -> dict:
         "sort": 1,
         "type": "query",
     }
+
+
+def clickhouse_datasource_variable() -> dict:
+    return {
+        "current": {
+            "selected": True,
+            "text": "prometheus-davidapps-cluster",
+            "value": "prometheus-davidapps-cluster",
+        },
+        "description": "Prometheus receiver for the cluster that owns the selected ClickHouse job.",
+        "hide": 0,
+        "includeAll": False,
+        "label": "Metrics source",
+        "multi": False,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/prometheus-(davidapps|home)-cluster/",
+        "skipUrlSync": False,
+        "type": "datasource",
+    }
+
+
+def replace_prometheus_datasource(value: object, datasource: dict) -> None:
+    if isinstance(value, dict):
+        if value.get("type") == "prometheus" and "uid" in value:
+            value["uid"] = datasource["uid"]
+        for nested in value.values():
+            replace_prometheus_datasource(nested, datasource)
+    elif isinstance(value, list):
+        for nested in value:
+            replace_prometheus_datasource(nested, datasource)
 
 
 def build_all_projects() -> None:
@@ -1448,19 +1482,27 @@ def build_zerocut_delivery() -> None:
     )
 
     panels.append(row(41, "ClickHouse event analytics", 77))
-    clickhouse = 'job="clickhouse"'
-    clickhouse_pod = 'namespace="databases",pod=~"clickhouse-.*",container="app"'
+    clickhouse = 'namespace="personal-projects",job="zerocut-clickhouse"'
+    clickhouse_pod = 'namespace="personal-projects",pod=~"chi-zerocut-.*",container="clickhouse"'
+    clickhouse_pvc = (
+        'namespace="personal-projects",'
+        'persistentvolumeclaim=~"clickhouse-data-chi-zerocut-.*"'
+    )
     panels.extend(
         [
             stat(
                 stat_proto,
                 42,
-                "Available",
+                "Healthy shards",
                 0,
                 78,
                 6,
-                prom_target(f'min(up{{{clickhouse}}})', datasource=KUBE_PROM, instant=True),
-                description="One means Prometheus can scrape the ZeroCut ClickHouse instance.",
+                prom_target(
+                    f'count(ClickHouseAsyncMetrics_Uptime{{{clickhouse}}})',
+                    datasource=PROM,
+                    instant=True,
+                ),
+                description="Three means every unique production shard is reporting.",
             ),
             stat(
                 stat_proto,
@@ -1471,7 +1513,7 @@ def build_zerocut_delivery() -> None:
                 6,
                 prom_target(
                     f'sum(ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables{{{clickhouse}}})',
-                    datasource=KUBE_PROM,
+                    datasource=PROM,
                     instant=True,
                 ),
                 unit="bytes",
@@ -1485,22 +1527,24 @@ def build_zerocut_delivery() -> None:
                 6,
                 prom_target(
                     f'sum(ClickHouseAsyncMetrics_TotalRowsOfMergeTreeTables{{{clickhouse}}})',
-                    datasource=KUBE_PROM,
+                    datasource=PROM,
                     instant=True,
                 ),
             ),
             stat(
                 stat_proto,
                 45,
-                "Parts",
+                "S3 backup age",
                 18,
                 78,
                 6,
                 prom_target(
-                    f'sum(ClickHouseAsyncMetrics_TotalPartsOfMergeTreeTables{{{clickhouse}}})',
-                    datasource=KUBE_PROM,
+                    'time() - min(clickhouse_backup_last_create_remote_finish{'
+                    'namespace="personal-projects",clickhouse_altinity_com_replica="0"} > 0)',
+                    datasource=PROM,
                     instant=True,
                 ),
+                unit="s",
             ),
             timeseries(
                 ts_proto,
@@ -1513,13 +1557,13 @@ def build_zerocut_delivery() -> None:
                     prom_target(
                         f'sum(rate(ClickHouseProfileEvents_SelectQuery{{{clickhouse}}}[$__rate_interval]))',
                         "select",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="A",
                     ),
                     prom_target(
                         f'sum(rate(ClickHouseProfileEvents_InsertQuery{{{clickhouse}}}[$__rate_interval]))',
                         "insert",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="B",
                     ),
                 ],
@@ -1536,13 +1580,13 @@ def build_zerocut_delivery() -> None:
                     prom_target(
                         f'1e-6 * sum(rate(ClickHouseProfileEvents_QueryTimeMicroseconds{{{clickhouse}}}[$__rate_interval])) / clamp_min(sum(rate(ClickHouseProfileEvents_Query{{{clickhouse}}}[$__rate_interval])), 0.000001)',
                         "average query seconds",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="A",
                     ),
                     prom_target(
                         f'100 * sum(rate(ClickHouseProfileEvents_FailedQuery{{{clickhouse}}}[$__rate_interval])) / clamp_min(sum(rate(ClickHouseProfileEvents_Query{{{clickhouse}}}[$__rate_interval])), 0.000001)',
                         "failed query percent",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="B",
                     ),
                 ],
@@ -1558,19 +1602,19 @@ def build_zerocut_delivery() -> None:
                     prom_target(
                         f'sum(rate(ClickHouseErrorMetric_ALL{{{clickhouse}}}[$__rate_interval]))',
                         "errors / second",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="A",
                     ),
                     prom_target(
                         f'sum(ClickHouseMetrics_Query{{{clickhouse}}})',
                         "queries",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="B",
                     ),
                     prom_target(
                         f'sum(ClickHouseMetrics_Merge{{{clickhouse}}})',
                         "merges",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="C",
                     ),
                 ],
@@ -1579,7 +1623,7 @@ def build_zerocut_delivery() -> None:
             timeseries(
                 ts_proto,
                 49,
-                "Memory and shared SSD headroom",
+                "Memory and NVMe volume use",
                 12,
                 91,
                 12,
@@ -1587,18 +1631,18 @@ def build_zerocut_delivery() -> None:
                     prom_target(
                         f'sum(container_memory_working_set_bytes{{{clickhouse_pod}}})',
                         "container memory",
-                        datasource=KUBE_PROM,
+                        datasource=PROM,
                         ref_id="A",
                     ),
                     prom_target(
-                        f'min(ClickHouseAsyncMetrics_DiskAvailable_default{{{clickhouse}}})',
-                        "shared analytics SSD free",
-                        datasource=KUBE_PROM,
+                        f'sum(kubelet_volume_stats_used_bytes{{{clickhouse_pvc}}})',
+                        "ClickHouse PVC used",
+                        datasource=PROM,
                         ref_id="B",
                     ),
                 ],
                 unit="bytes",
-                description="Disk free is for the shared analytics filesystem; MergeTree data is the instance-specific footprint.",
+                description="The PVCs are node-local thin ZFS volumes; this is written data, not their logical growth ceiling.",
             ),
         ]
     )
@@ -1635,12 +1679,14 @@ def build_clickhouse_dashboard() -> None:
             "title": "ClickHouse Instances",
             "description": (
                 "Health, query workload, MergeTree storage, errors, and Kubernetes resources "
-                "for the ZeroCut and Plausible ClickHouse instances. Disk-free metrics describe "
-                "their shared analytics SSD; MergeTree bytes are instance-specific."
+                "for the ZeroCut and Plausible ClickHouse instances. Select the owning cluster's "
+                "Prometheus receiver before selecting an instance."
             ),
             "links": [],
             "tags": ["clickhouse", "databases", "plausible", "zerocut"],
-            "templating": {"list": [clickhouse_variable()]},
+            "templating": {
+                "list": [clickhouse_datasource_variable(), clickhouse_variable()]
+            },
             "time": {"from": "now-24h", "to": "now"},
             "version": 1,
         }
@@ -1648,8 +1694,13 @@ def build_clickhouse_dashboard() -> None:
 
     instance = 'job=~"${instance:regex}"'
     clickhouse_pods = (
-        'namespace=~"databases|observability",'
-        'pod=~"(${instance:regex})-.*",container="app"'
+        'namespace=~"databases|observability|personal-projects",'
+        'pod=~"(clickhouse|plausible-clickhouse|chi-zerocut)-.*",'
+        'container=~"app|clickhouse"'
+    )
+    clickhouse_pod_names = (
+        'namespace=~"databases|observability|personal-projects",'
+        'pod=~"(clickhouse|plausible-clickhouse|chi-zerocut)-.*"'
     )
     panels: list[dict] = [row(1, "Overview", 0)]
     overview_stats = [
@@ -1659,8 +1710,8 @@ def build_clickhouse_dashboard() -> None:
         (5, "Rows", 'sum(ClickHouseAsyncMetrics_TotalRowsOfMergeTreeTables{' + instance + '})', "short", None),
         (6, "Parts", 'sum(ClickHouseAsyncMetrics_TotalPartsOfMergeTreeTables{' + instance + '})', "short", None),
         (7, "Resident memory", 'sum(ClickHouseAsyncMetrics_MemoryResident{' + instance + '})', "bytes", None),
-        (8, "Shared SSD free", 'min(ClickHouseAsyncMetrics_DiskAvailable_default{' + instance + '})', "bytes", "Free space on the shared analytics filesystem, not an instance allocation."),
-        (9, "Restarts · selected range", 'sum(increase(kube_pod_container_status_restarts_total{namespace=~"databases|observability",pod=~"(${instance:regex})-.*",container="app"}[$__range]))', "short", None),
+        (8, "Minimum local disk free", 'min(ClickHouseAsyncMetrics_DiskAvailable_default{' + instance + '})', "bytes", "Minimum free space reported by a selected ClickHouse server."),
+        (9, "Restarts · selected range", 'sum(increase(kube_pod_container_status_restarts_total{namespace=~"databases|observability|personal-projects",pod=~"(clickhouse|plausible-clickhouse|chi-zerocut)-.*",container=~"app|clickhouse"}[$__range]))', "short", None),
     ]
     for offset, (panel_id, title, expr, unit, description) in enumerate(overview_stats):
         panels.append(
@@ -1779,11 +1830,112 @@ def build_clickhouse_dashboard() -> None:
         [
             timeseries(ts_proto, 41, "Container memory", 0, 74, 12, [prom_target(f'sum by (namespace, pod) (container_memory_working_set_bytes{{{clickhouse_pods}}})', "{{namespace}} / {{pod}}", datasource=KUBE_PROM)], unit="bytes"),
             timeseries(ts_proto, 42, "Container CPU", 12, 74, 12, [prom_target(f'sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{{{clickhouse_pods}}}[$__rate_interval]))', "{{namespace}} / {{pod}}", datasource=KUBE_PROM)], unit="cores"),
-            timeseries(ts_proto, 43, "Container network", 0, 82, 12, [prom_target('sum by (namespace, pod) (rate(container_network_receive_bytes_total{namespace=~"databases|observability",pod=~"(${instance:regex})-.*"}[$__rate_interval]))', "receive · {{namespace}} / {{pod}}", datasource=KUBE_PROM, ref_id="A"), prom_target('sum by (namespace, pod) (rate(container_network_transmit_bytes_total{namespace=~"databases|observability",pod=~"(${instance:regex})-.*"}[$__rate_interval]))', "transmit · {{namespace}} / {{pod}}", datasource=KUBE_PROM, ref_id="B")], unit="Bps"),
+            timeseries(ts_proto, 43, "Container network", 0, 82, 12, [prom_target(f'sum by (namespace, pod) (rate(container_network_receive_bytes_total{{{clickhouse_pod_names}}}[$__rate_interval]))', "receive · {{namespace}} / {{pod}}", datasource=KUBE_PROM, ref_id="A"), prom_target(f'sum by (namespace, pod) (rate(container_network_transmit_bytes_total{{{clickhouse_pod_names}}}[$__rate_interval]))', "transmit · {{namespace}} / {{pod}}", datasource=KUBE_PROM, ref_id="B")], unit="Bps"),
             timeseries(ts_proto, 44, "Container filesystem I/O", 12, 82, 12, [prom_target(f'sum by (namespace, pod) (rate(container_fs_reads_bytes_total{{{clickhouse_pods}}}[$__rate_interval]))', "read · {{namespace}} / {{pod}}", datasource=KUBE_PROM, ref_id="A"), prom_target(f'sum by (namespace, pod) (rate(container_fs_writes_bytes_total{{{clickhouse_pods}}}[$__rate_interval]))', "write · {{namespace}} / {{pod}}", datasource=KUBE_PROM, ref_id="B")], unit="Bps"),
         ]
     )
 
+    panels.append(row(50, "S3 backups and node-local storage", 90))
+    panels.extend(
+        [
+            stat(
+                stat_proto,
+                51,
+                "Oldest shard backup",
+                0,
+                91,
+                6,
+                prom_target(
+                    'time() - min(clickhouse_backup_last_create_remote_finish{namespace="personal-projects",clickhouse_altinity_com_replica="0"} > 0)',
+                    datasource=CLICKHOUSE_PROM,
+                    instant=True,
+                ),
+                unit="s",
+            ),
+            stat(
+                stat_proto,
+                52,
+                "Remote backup inventory",
+                6,
+                91,
+                6,
+                prom_target(
+                    'sum(clickhouse_backup_number_backups_remote{namespace="personal-projects",clickhouse_altinity_com_replica="0"})',
+                    datasource=CLICKHOUSE_PROM,
+                    instant=True,
+                ),
+            ),
+            stat(
+                stat_proto,
+                53,
+                "Production shards",
+                12,
+                91,
+                6,
+                prom_target(
+                    'count(ClickHouseAsyncMetrics_Uptime{namespace="personal-projects",job="zerocut-clickhouse"})',
+                    datasource=CLICKHOUSE_PROM,
+                    instant=True,
+                ),
+                description="The single-copy production target is exactly three unique shards.",
+            ),
+            stat(
+                stat_proto,
+                54,
+                "Highest PVC utilization",
+                18,
+                91,
+                6,
+                prom_target(
+                    '100 * max(kubelet_volume_stats_used_bytes{namespace="personal-projects",persistentvolumeclaim=~"clickhouse-data-chi-zerocut-.*"} / kubelet_volume_stats_capacity_bytes{namespace="personal-projects",persistentvolumeclaim=~"clickhouse-data-chi-zerocut-.*"})',
+                    datasource=CLICKHOUSE_PROM,
+                    instant=True,
+                ),
+                unit="percent",
+            ),
+            timeseries(
+                ts_proto,
+                55,
+                "Backup age by shard",
+                0,
+                96,
+                12,
+                [
+                    prom_target(
+                        'time() - max by (clickhouse_altinity_com_shard) (clickhouse_backup_last_create_remote_finish{namespace="personal-projects",clickhouse_altinity_com_replica="0"} > 0)',
+                        "{{clickhouse_altinity_com_shard}}",
+                        datasource=CLICKHOUSE_PROM,
+                    )
+                ],
+                unit="s",
+            ),
+            timeseries(
+                ts_proto,
+                56,
+                "ClickHouse PVC use",
+                12,
+                96,
+                12,
+                [
+                    prom_target(
+                        'kubelet_volume_stats_used_bytes{namespace="personal-projects",persistentvolumeclaim=~"clickhouse-data-chi-zerocut-.*"}',
+                        "used · {{persistentvolumeclaim}}",
+                        datasource=CLICKHOUSE_PROM,
+                        ref_id="A",
+                    ),
+                    prom_target(
+                        'kubelet_volume_stats_capacity_bytes{namespace="personal-projects",persistentvolumeclaim=~"clickhouse-data-chi-zerocut-.*"}',
+                        "ceiling · {{persistentvolumeclaim}}",
+                        datasource=CLICKHOUSE_PROM,
+                        ref_id="B",
+                    ),
+                ],
+                unit="bytes",
+            ),
+        ]
+    )
+
+    replace_prometheus_datasource(panels, CLICKHOUSE_PROM)
     dashboard["panels"] = panels
     save("clickhouse-instances.json", dashboard)
 

--- a/kubernetes/apps/observability/grafana/app/dashboards/clickhouse-instances.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/clickhouse-instances.json
@@ -36,7 +36,7 @@
   "id": null,
   "uid": "clickhouse-instances",
   "title": "ClickHouse Instances",
-  "description": "Health, query workload, MergeTree storage, errors, and Kubernetes resources for the ZeroCut and Plausible ClickHouse instances. Disk-free metrics describe their shared analytics SSD; MergeTree bytes are instance-specific.",
+  "description": "Health, query workload, MergeTree storage, errors, and Kubernetes resources for the ZeroCut and Plausible ClickHouse instances. Select the owning cluster's Prometheus receiver before selecting an instance.",
   "links": [],
   "tags": [
     "clickhouse",
@@ -46,6 +46,25 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "prometheus-davidapps-cluster",
+          "value": "prometheus-davidapps-cluster"
+        },
+        "description": "Prometheus receiver for the cluster that owns the selected ClickHouse job.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Metrics source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/prometheus-(davidapps|home)-cluster/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "allValue": "clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse",
         "current": {
@@ -59,7 +78,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus-home-cluster"
+          "uid": "${datasource}"
         },
         "definition": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"clickhouse|plausible-clickhouse|zerocut-canary-clickhouse|zerocut-clickhouse\"}, job)",
         "description": "ClickHouse ServiceMonitor scrape job.",
@@ -76,39 +95,6 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus-home-cluster"
-        },
-        "definition": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"${instance:regex}\"}, pod)",
-        "description": "Pods belonging to the selected ClickHouse scrape jobs.",
-        "hide": 2,
-        "includeAll": true,
-        "label": "Pod",
-        "multi": true,
-        "name": "pod",
-        "options": [],
-        "query": {
-          "query": "label_values(ClickHouseAsyncMetrics_Uptime{job=~\"${instance:regex}\"}, pod)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": true,
         "sort": 1,
         "type": "query"
       }
@@ -139,7 +125,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -188,7 +174,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(up{job=~\"${instance:regex}\"})",
@@ -206,7 +192,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -255,7 +241,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(ClickHouseAsyncMetrics_Uptime{job=~\"${instance:regex}\"})",
@@ -272,7 +258,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -321,7 +307,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables{job=~\"${instance:regex}\"})",
@@ -338,7 +324,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -387,7 +373,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(ClickHouseAsyncMetrics_TotalRowsOfMergeTreeTables{job=~\"${instance:regex}\"})",
@@ -404,7 +390,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -453,7 +439,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(ClickHouseAsyncMetrics_TotalPartsOfMergeTreeTables{job=~\"${instance:regex}\"})",
@@ -470,7 +456,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -519,7 +505,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(ClickHouseAsyncMetrics_MemoryResident{job=~\"${instance:regex}\"})",
@@ -532,11 +518,11 @@
     },
     {
       "id": 8,
-      "title": "Shared SSD free",
+      "title": "Minimum local disk free",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -585,7 +571,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(ClickHouseAsyncMetrics_DiskAvailable_default{job=~\"${instance:regex}\"})",
@@ -595,7 +581,7 @@
           "refId": "A"
         }
       ],
-      "description": "Free space on the shared analytics filesystem, not an instance allocation."
+      "description": "Minimum free space reported by a selected ClickHouse server."
     },
     {
       "id": 9,
@@ -603,7 +589,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 5,
@@ -652,10 +638,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(kube_pod_container_status_restarts_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__range]))",
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\",container=~\"app|clickhouse\"}[$__range]))",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -682,7 +668,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -728,7 +714,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_Query{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -745,7 +731,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -791,7 +777,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_SelectQuery{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -803,7 +789,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_InsertQuery{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -820,7 +806,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -866,7 +852,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "100 * sum by (job) (rate(ClickHouseProfileEvents_FailedQuery{job=~\"${instance:regex}\"}[$__rate_interval])) / clamp_min(sum by (job) (rate(ClickHouseProfileEvents_Query{job=~\"${instance:regex}\"}[$__rate_interval])), 0.000001)",
@@ -883,7 +869,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -929,7 +915,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "1e-6 * sum by (job) (rate(ClickHouseProfileEvents_QueryTimeMicroseconds{job=~\"${instance:regex}\"}[$__rate_interval])) / clamp_min(sum by (job) (rate(ClickHouseProfileEvents_Query{job=~\"${instance:regex}\"}[$__rate_interval])), 0.000001)",
@@ -946,7 +932,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -992,7 +978,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_SelectedRows{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1004,7 +990,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_InsertedRows{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1021,7 +1007,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1067,7 +1053,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_SelectedBytes{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1079,7 +1065,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_InsertedBytes{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1109,7 +1095,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1155,7 +1141,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables{job=~\"${instance:regex}\"})",
@@ -1172,7 +1158,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1218,7 +1204,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseAsyncMetrics_TotalRowsOfMergeTreeTables{job=~\"${instance:regex}\"})",
@@ -1230,7 +1216,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseAsyncMetrics_TotalPartsOfMergeTreeTables{job=~\"${instance:regex}\"})",
@@ -1247,7 +1233,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1293,7 +1279,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max by (job) (ClickHouseAsyncMetrics_MaxPartCountForPartition{job=~\"${instance:regex}\"})",
@@ -1310,7 +1296,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1356,7 +1342,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseMetrics_Merge{job=~\"${instance:regex}\"})",
@@ -1368,7 +1354,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseMetrics_PartMutation{job=~\"${instance:regex}\"})",
@@ -1380,7 +1366,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseMetrics_DelayedInserts{job=~\"${instance:regex}\"})",
@@ -1397,7 +1383,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1443,7 +1429,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseProfileEvents_MergedRows{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1460,7 +1446,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1506,7 +1492,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "100 * sum by (job) (rate(ClickHouseProfileEvents_MarkCacheHits{job=~\"${instance:regex}\"}[$__rate_interval])) / clamp_min(sum by (job) (rate(ClickHouseProfileEvents_MarkCacheHits{job=~\"${instance:regex}\"}[$__rate_interval]) + rate(ClickHouseProfileEvents_MarkCacheMisses{job=~\"${instance:regex}\"}[$__rate_interval])), 0.000001)",
@@ -1536,7 +1522,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1582,7 +1568,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseErrorMetric_ALL{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1599,7 +1585,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1645,7 +1631,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseErrorMetric_MEMORY_LIMIT_EXCEEDED{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1657,7 +1643,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseErrorMetric_TOO_MANY_PARTS{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1674,7 +1660,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1720,7 +1706,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseErrorMetric_TIMEOUT_EXCEEDED{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1732,7 +1718,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (rate(ClickHouseErrorMetric_NETWORK_ERROR{job=~\"${instance:regex}\"}[$__rate_interval]))",
@@ -1749,7 +1735,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1795,7 +1781,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseMetrics_Query{job=~\"${instance:regex}\"})",
@@ -1807,7 +1793,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (job) (ClickHouseMetrics_Merge{job=~\"${instance:regex}\"})",
@@ -1837,7 +1823,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1883,10 +1869,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (container_memory_working_set_bytes{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"})",
+          "expr": "sum by (namespace, pod) (container_memory_working_set_bytes{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\",container=~\"app|clickhouse\"})",
           "legendFormat": "{{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -1900,7 +1886,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -1946,10 +1932,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\",container=~\"app|clickhouse\"}[$__rate_interval]))",
           "legendFormat": "{{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -1963,7 +1949,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -2009,10 +1995,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_network_receive_bytes_total{pod=~\"${pod:regex}\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_network_receive_bytes_total{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\"}[$__rate_interval]))",
           "legendFormat": "receive \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -2021,10 +2007,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_network_transmit_bytes_total{pod=~\"${pod:regex}\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_network_transmit_bytes_total{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\"}[$__rate_interval]))",
           "legendFormat": "transmit \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -2038,7 +2024,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 8,
@@ -2084,10 +2070,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_fs_reads_bytes_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_fs_reads_bytes_total{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\",container=~\"app|clickhouse\"}[$__rate_interval]))",
           "legendFormat": "read \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -2096,10 +2082,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(container_fs_writes_bytes_total{pod=~\"${pod:regex}\",container=~\"app|clickhouse|clickhouse-backup\"}[$__rate_interval]))",
+          "expr": "sum by (namespace, pod) (rate(container_fs_writes_bytes_total{namespace=~\"databases|observability|personal-projects\",pod=~\"(clickhouse|plausible-clickhouse|chi-zerocut)-.*\",container=~\"app|clickhouse\"}[$__rate_interval]))",
           "legendFormat": "write \u00b7 {{namespace}} / {{pod}}",
           "range": true,
           "instant": false,
@@ -2115,42 +2101,47 @@
         "x": 0,
         "y": 90
       },
-      "id": 45,
+      "id": 50,
       "panels": [],
-      "title": "Recovery backups",
+      "title": "S3 backups and node-local storage",
       "type": "row"
     },
     {
+      "id": 51,
+      "title": "Oldest shard backup",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 28800
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
+        "uid": "${datasource}"
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 6,
         "x": 0,
         "y": 91
       },
-      "id": 46,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -2170,169 +2161,37 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "time() - (clickhouse_backup_last_create_remote_finish{job=~\"${instance:regex}\",clickhouse_altinity_com_replica=\"0\"} > 0)",
-          "instant": true,
-          "legendFormat": "{{pod}}",
+          "expr": "time() - min(clickhouse_backup_last_create_remote_finish{namespace=\"personal-projects\",clickhouse_altinity_com_replica=\"0\"} > 0)",
+          "legendFormat": "",
           "range": false,
+          "instant": true,
           "refId": "A"
         }
-      ],
-      "title": "Remote backup age",
-      "type": "stat"
+      ]
     },
     {
+      "id": 52,
+      "title": "Remote backup inventory",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "text": "Failed"
-                },
-                "1": {
-                  "color": "green",
-                  "text": "Succeeded"
-                },
-                "2": {
-                  "color": "yellow",
-                  "text": "Not run"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              },
-              {
-                "color": "yellow",
-                "value": 2
-              }
-            ]
-          }
-        },
-        "overrides": []
+        "uid": "${datasource}"
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 6,
         "x": 6,
         "y": 91
       },
-      "id": 47,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
-          },
-          "editorMode": "code",
-          "expr": "clickhouse_backup_last_create_remote_status{job=~\"${instance:regex}\",clickhouse_altinity_com_replica=\"0\"}",
-          "instant": true,
-          "legendFormat": "{{pod}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Last remote backup",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
       "fieldConfig": {
         "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 91
-      },
-      "id": 48,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
           },
-          "editorMode": "code",
-          "expr": "clickhouse_backup_number_backups_remote{job=~\"${instance:regex}\",clickhouse_altinity_com_replica=\"0\"}",
-          "instant": true,
-          "legendFormat": "{{pod}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Remote backups retained",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus-home-cluster"
-      },
-      "fieldConfig": {
-        "defaults": {
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2349,13 +2208,6 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 91
-      },
-      "id": 49,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -2375,18 +2227,287 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(clickhouse_backup_failed_create_remotes{job=~\"${instance:regex}\"}[$__range])) + sum(increase(clickhouse_backup_failed_parts_count{job=~\"${instance:regex}\"}[$__range]))",
-          "instant": true,
+          "expr": "sum(clickhouse_backup_number_backups_remote{namespace=\"personal-projects\",clickhouse_altinity_com_replica=\"0\"})",
           "legendFormat": "",
           "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 53,
+      "title": "Production shards",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 91
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(ClickHouseAsyncMetrics_Uptime{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
           "refId": "A"
         }
       ],
-      "title": "Backup failures in range",
-      "type": "stat"
+      "description": "The single-copy production target is exactly three unique shards."
+    },
+    {
+      "id": 54,
+      "title": "Highest PVC utilization",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 91
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "100 * max(kubelet_volume_stats_used_bytes{namespace=\"personal-projects\",persistentvolumeclaim=~\"clickhouse-data-chi-zerocut-.*\"} / kubelet_volume_stats_capacity_bytes{namespace=\"personal-projects\",persistentvolumeclaim=~\"clickhouse-data-chi-zerocut-.*\"})",
+          "legendFormat": "",
+          "range": false,
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 55,
+      "title": "Backup age by shard",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "time() - max by (clickhouse_altinity_com_shard) (clickhouse_backup_last_create_remote_finish{namespace=\"personal-projects\",clickhouse_altinity_com_replica=\"0\"} > 0)",
+          "legendFormat": "{{clickhouse_altinity_com_shard}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 56,
+      "title": "ClickHouse PVC use",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 96
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "kubelet_volume_stats_used_bytes{namespace=\"personal-projects\",persistentvolumeclaim=~\"clickhouse-data-chi-zerocut-.*\"}",
+          "legendFormat": "used \u00b7 {{persistentvolumeclaim}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "kubelet_volume_stats_capacity_bytes{namespace=\"personal-projects\",persistentvolumeclaim=~\"clickhouse-data-chi-zerocut-.*\"}",
+          "legendFormat": "ceiling \u00b7 {{persistentvolumeclaim}}",
+          "range": true,
+          "instant": false,
+          "refId": "B"
+        }
+      ]
     }
   ]
 }

--- a/kubernetes/apps/observability/grafana/app/dashboards/zerocut-delivery-data.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/zerocut-delivery-data.json
@@ -1767,11 +1767,11 @@
     },
     {
       "id": 42,
-      "title": "Available",
+      "title": "Healthy shards",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 5,
@@ -1820,17 +1820,17 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"clickhouse\"})",
+          "expr": "count(ClickHouseAsyncMetrics_Uptime{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,
           "refId": "A"
         }
       ],
-      "description": "One means Prometheus can scrape the ZeroCut ClickHouse instance."
+      "description": "Three means every unique production shard is reporting."
     },
     {
       "id": 43,
@@ -1838,7 +1838,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 5,
@@ -1887,10 +1887,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables{job=\"clickhouse\"})",
+          "expr": "sum(ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -1904,7 +1904,7 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 5,
@@ -1953,10 +1953,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(ClickHouseAsyncMetrics_TotalRowsOfMergeTreeTables{job=\"clickhouse\"})",
+          "expr": "sum(ClickHouseAsyncMetrics_TotalRowsOfMergeTreeTables{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"})",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -1966,11 +1966,11 @@
     },
     {
       "id": 45,
-      "title": "Parts",
+      "title": "S3 backup age",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 5,
@@ -1980,7 +1980,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "s",
           "color": {
             "mode": "thresholds"
           },
@@ -2019,10 +2019,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(ClickHouseAsyncMetrics_TotalPartsOfMergeTreeTables{job=\"clickhouse\"})",
+          "expr": "time() - min(clickhouse_backup_last_create_remote_finish{namespace=\"personal-projects\",clickhouse_altinity_com_replica=\"0\"} > 0)",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -2036,7 +2036,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 8,
@@ -2082,10 +2082,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(rate(ClickHouseProfileEvents_SelectQuery{job=\"clickhouse\"}[$__rate_interval]))",
+          "expr": "sum(rate(ClickHouseProfileEvents_SelectQuery{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval]))",
           "legendFormat": "select",
           "range": true,
           "instant": false,
@@ -2094,10 +2094,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(rate(ClickHouseProfileEvents_InsertQuery{job=\"clickhouse\"}[$__rate_interval]))",
+          "expr": "sum(rate(ClickHouseProfileEvents_InsertQuery{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval]))",
           "legendFormat": "insert",
           "range": true,
           "instant": false,
@@ -2111,7 +2111,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 8,
@@ -2157,10 +2157,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "1e-6 * sum(rate(ClickHouseProfileEvents_QueryTimeMicroseconds{job=\"clickhouse\"}[$__rate_interval])) / clamp_min(sum(rate(ClickHouseProfileEvents_Query{job=\"clickhouse\"}[$__rate_interval])), 0.000001)",
+          "expr": "1e-6 * sum(rate(ClickHouseProfileEvents_QueryTimeMicroseconds{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval])) / clamp_min(sum(rate(ClickHouseProfileEvents_Query{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "average query seconds",
           "range": true,
           "instant": false,
@@ -2169,10 +2169,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "100 * sum(rate(ClickHouseProfileEvents_FailedQuery{job=\"clickhouse\"}[$__rate_interval])) / clamp_min(sum(rate(ClickHouseProfileEvents_Query{job=\"clickhouse\"}[$__rate_interval])), 0.000001)",
+          "expr": "100 * sum(rate(ClickHouseProfileEvents_FailedQuery{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval])) / clamp_min(sum(rate(ClickHouseProfileEvents_Query{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "failed query percent",
           "range": true,
           "instant": false,
@@ -2186,7 +2186,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 8,
@@ -2232,10 +2232,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(rate(ClickHouseErrorMetric_ALL{job=\"clickhouse\"}[$__rate_interval]))",
+          "expr": "sum(rate(ClickHouseErrorMetric_ALL{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"}[$__rate_interval]))",
           "legendFormat": "errors / second",
           "range": true,
           "instant": false,
@@ -2244,10 +2244,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(ClickHouseMetrics_Query{job=\"clickhouse\"})",
+          "expr": "sum(ClickHouseMetrics_Query{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"})",
           "legendFormat": "queries",
           "range": true,
           "instant": false,
@@ -2256,10 +2256,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(ClickHouseMetrics_Merge{job=\"clickhouse\"})",
+          "expr": "sum(ClickHouseMetrics_Merge{namespace=\"personal-projects\",job=\"zerocut-clickhouse\"})",
           "legendFormat": "merges",
           "range": true,
           "instant": false,
@@ -2269,11 +2269,11 @@
     },
     {
       "id": 49,
-      "title": "Memory and shared SSD headroom",
+      "title": "Memory and NVMe volume use",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus-home-cluster"
+        "uid": "prometheus-davidapps-cluster"
       },
       "gridPos": {
         "h": 8,
@@ -2319,10 +2319,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "sum(container_memory_working_set_bytes{namespace=\"databases\",pod=~\"clickhouse-.*\",container=\"app\"})",
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"personal-projects\",pod=~\"chi-zerocut-.*\",container=\"clickhouse\"})",
           "legendFormat": "container memory",
           "range": true,
           "instant": false,
@@ -2331,17 +2331,17 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus-home-cluster"
+            "uid": "prometheus-davidapps-cluster"
           },
           "editorMode": "code",
-          "expr": "min(ClickHouseAsyncMetrics_DiskAvailable_default{job=\"clickhouse\"})",
-          "legendFormat": "shared analytics SSD free",
+          "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"personal-projects\",persistentvolumeclaim=~\"clickhouse-data-chi-zerocut-.*\"})",
+          "legendFormat": "ClickHouse PVC used",
           "range": true,
           "instant": false,
           "refId": "B"
         }
       ],
-      "description": "Disk free is for the shared analytics filesystem; MergeTree data is the instance-specific footprint."
+      "description": "The PVCs are node-local thin ZFS volumes; this is written data, not their logical growth ceiling."
     }
   ]
 }

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -653,7 +653,7 @@ spec:
       infrastructure-databases:
         clickhouse:
           url: https://raw.githubusercontent.com/davidilie/home-cluster/main/kubernetes/apps/observability/grafana/app/dashboards/clickhouse-instances.json
-          datasource: prometheus-home-cluster
+          datasource: prometheus-davidapps-cluster
         dragonfly:
           url: https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/v1.1.8/monitoring/grafana-dashboard.json
           datasource: prometheus-davidapps-cluster


### PR DESCRIPTION
## Summary

- point ZeroCut ClickHouse panels at davidapps-cluster Prometheus
- add shard, S3 backup, query, memory, and PVC health panels
- make the generic ClickHouse dashboard switch cleanly between home and davidapps metrics
- update Grafana's dashboard datasource value so Flux rolls the release and fetches the new JSON

## Verification

- regenerated both dashboards twice with identical hashes
- `jq empty` on both generated JSON files
- validated the new PromQL against production Prometheus
- Kubernetes server-side dry-run of the Grafana HelmRelease
- `git diff --check`