### PR TITLE
fix(plausible): pass reader database URL explicitly

### DIFF
--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -35,8 +35,8 @@ spec:
             command: ["sh", "-ec"]
             args:
               - |
-                export PGDATABASE="$DATABASE_URL"
-                psql --variable=ON_ERROR_STOP=1 --file=/bootstrap/employee-hub-reader.sql
+                test -n "$DATABASE_URL"
+                psql --dbname="$DATABASE_URL" --variable=ON_ERROR_STOP=1 --file=/bootstrap/employee-hub-reader.sql
             env:
               DATABASE_URL:
                 valueFrom:


### PR DESCRIPTION
The pinned PostgreSQL client does not interpret the Plausible connection URL through PGDATABASE in this runtime and fell back to the local Unix socket. Pass the validated secret as an explicit --dbname value. Verified with an in-cluster one-shot probe using the same pinned image, UID/GID, security context, and Secret reference.