### PR TITLE
feat(cliproxy): expose employee key reveal route

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/employee-hub-secret.sops.yaml
+++ b/kubernetes/apps/default/cliproxy/app/employee-hub-secret.sops.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cliproxy-employee-hub
 stringData:
   EMPLOYEE_HUB_SERVICE_TOKEN: ENC[AES256_GCM,data:7aj33k7DrIDxOlF052AirE4gKUVQLDX+4sBonwdmB8jMVgRfMB9XytLP393mcg67nko9yu4lAPTKe8cNMAsX7Q==,iv:6LRx5TWiXgOjowIB8WkmGqdxhPVWofBFIMhTmW/SWl4=,tag:VwyFXGcqq0NM7NToe6+g4w==,type:str]
+  EMPLOYEE_HUB_REVEAL_TOKEN: ENC[AES256_GCM,data:uhsiGpciRG7n0sUbbNErjZB3Gf4R9eLKp16oNip6cwek+q7BZa+tTUw+lsULqnGAfolCMTS7TEb6vfeKvkXUNQ==,iv:1lwjR/Mn5knAwxIqJQ/43XEar+iSVFPLrYKac7Q+gm8=,tag:ZNqWG97lR+PpvfD5C9hSJg==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -15,8 +16,8 @@ sops:
         OXJmeGU0OEFLSVM0UEFtUzV5YU50L28K0Kfyk11vf0LMjngFpqfR7ZDQO1A9RMVN
         A/NmVaMufTyXuUksE2FSSP2+ztN3iGLpPBM4VPtCz3r6y9BWQuHC3g==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-24T20:29:09Z"
-  mac: ENC[AES256_GCM,data:WUzf2hhDX7gzSrJRrmCvhCXr9b6/pwUcyKc6kY27+DTRYu5f1jrdU140JYcOFOSLawZn5NNQ5ILyL3xttnVS0z75+tetHlGSgLpCFm1GrJmBFUCbMvpLE1nyAam6AisD7S6ap8xKjxoddxMVY8NmHaLi2KicHiZeJVBpNYEb3jU=,iv:MOZyaYk26RXyVYDcdrAgkGZ43q2IcQq6ZRQN1Z35Xzc=,tag:62lX5H20/RW7VWE8+pchgg==,type:str]
+  lastmodified: "2026-08-25T16:41:51Z"
+  mac: ENC[AES256_GCM,data:upgekzV5zJBBmP3DYK6/B9CuMV4ph8fJDxJWgZmI5qoMrA3K5wyadIvKG7BTYJHsHhSNKsozFSsJ2DrfteSbKj1FADEQQRUGshjZs0jj0xk6PlXg4sZFPG7I5LsfJgU+Zvll392ezc4YmOkAs/c9agj37oVxcc0fucyFq8OOl2w=,iv:SWhPHt6DhKtQzTLcUMyD2UbUuM8RFrMhCqTBgFLLbag=,tag:JpQkxIUmD/LBYXhiyATeEA==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -183,6 +183,11 @@ spec:
                   secretKeyRef:
                     name: cliproxy-employee-hub
                     key: EMPLOYEE_HUB_SERVICE_TOKEN
+              EMPLOYEE_HUB_REVEAL_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: cliproxy-employee-hub
+                    key: EMPLOYEE_HUB_REVEAL_TOKEN
               # Persist managed-key quota attribution across rollouts on the
               # dedicated, backed-up plugin data volume.
               CLIPROXY_QUOTA_LEDGER_PATH: /CLIProxyAPI/plugin-data/managed-key-quota-ledger.json
@@ -262,6 +267,9 @@ spec:
               - path: /healthz
                 service: *appService
               - path: /internal/employee-hub/v1/usage
+                pathType: Exact
+                service: *appService
+              - path: /internal/employee-hub/v1/api-key/reveal
                 pathType: Exact
                 service: *appService
           - host: &apiHost "cliproxyapi.davidhome.ro"


### PR DESCRIPTION
## Summary
- expose the exact Employee Hub API-key reveal endpoint through the external ingress
- inject a dedicated SOPS-encrypted reveal token into CLIProxyAPI
- keep the reveal credential separate from the existing usage credential

## Validation
- `kustomize build kubernetes/apps/default/cliproxy/app`
- targeted `flux-local` Kustomization and HelmRelease tests
- SOPS file status and cross-repository token equality/separation checks (values never printed)

## Dependency
Deploy after CLIProxyAPI PR #2 is merged and its image is available.