### PR TITLE
feat(cliproxy): enable Employee Hub owner binding

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/employee-hub-secret.sops.yaml
+++ b/kubernetes/apps/default/cliproxy/app/employee-hub-secret.sops.yaml
@@ -5,6 +5,7 @@ metadata:
 stringData:
   EMPLOYEE_HUB_SERVICE_TOKEN: ENC[AES256_GCM,data:7aj33k7DrIDxOlF052AirE4gKUVQLDX+4sBonwdmB8jMVgRfMB9XytLP393mcg67nko9yu4lAPTKe8cNMAsX7Q==,iv:6LRx5TWiXgOjowIB8WkmGqdxhPVWofBFIMhTmW/SWl4=,tag:VwyFXGcqq0NM7NToe6+g4w==,type:str]
   EMPLOYEE_HUB_REVEAL_TOKEN: ENC[AES256_GCM,data:uhsiGpciRG7n0sUbbNErjZB3Gf4R9eLKp16oNip6cwek+q7BZa+tTUw+lsULqnGAfolCMTS7TEb6vfeKvkXUNQ==,iv:1lwjR/Mn5knAwxIqJQ/43XEar+iSVFPLrYKac7Q+gm8=,tag:ZNqWG97lR+PpvfD5C9hSJg==,type:str]
+  EMPLOYEE_HUB_BINDING_TOKEN: ENC[AES256_GCM,data:8kKZmWtLgCiu8nvg1UJE/RqUcuUGxDczkAoyaeefR8MvUABw8XUVc5dv7SGy4IOIcI+cRl1TQ2KbKZWmbnMESkkHgHKsX7LDVU9z03rPivP3hl6e4u5+0bhrzdVhEyme,iv:z1n9LAD4H9G2bA121TT9VA37BAXMLMz7LP1InR86hZ0=,tag:17Nl2ZLK2E1diSN5K6hWvg==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -16,8 +17,8 @@ sops:
         OXJmeGU0OEFLSVM0UEFtUzV5YU50L28K0Kfyk11vf0LMjngFpqfR7ZDQO1A9RMVN
         A/NmVaMufTyXuUksE2FSSP2+ztN3iGLpPBM4VPtCz3r6y9BWQuHC3g==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-25T16:41:51Z"
-  mac: ENC[AES256_GCM,data:upgekzV5zJBBmP3DYK6/B9CuMV4ph8fJDxJWgZmI5qoMrA3K5wyadIvKG7BTYJHsHhSNKsozFSsJ2DrfteSbKj1FADEQQRUGshjZs0jj0xk6PlXg4sZFPG7I5LsfJgU+Zvll392ezc4YmOkAs/c9agj37oVxcc0fucyFq8OOl2w=,iv:SWhPHt6DhKtQzTLcUMyD2UbUuM8RFrMhCqTBgFLLbag=,tag:JpQkxIUmD/LBYXhiyATeEA==,type:str]
+  lastmodified: "2026-08-25T17:39:33Z"
+  mac: ENC[AES256_GCM,data:3ebJBLfVarunUmVqyIO44OHc2ERfCUU12OGm68Y54D7LKEDBZlC7IX5mFDEjR6jjG4HaK8GshXZg0O7wgAk5qu6Gz1h1QyQrq9LLOgBb0/kWXR+oYMxFBuctRGUFs4DATNhFiE2Z9YKufymuBFb/GCto8eQI7gAlntgoerPlVSs=,iv:pn/NBQJZIMYu+s8WNoXNFbGPkwaXowq0pKiiRwYYngQ=,tag:zsbaS7Z2l8k/U+EP0n/KGw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -188,6 +188,11 @@ spec:
                   secretKeyRef:
                     name: cliproxy-employee-hub
                     key: EMPLOYEE_HUB_REVEAL_TOKEN
+              EMPLOYEE_HUB_BINDING_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: cliproxy-employee-hub
+                    key: EMPLOYEE_HUB_BINDING_TOKEN
               # Persist managed-key quota attribution across rollouts on the
               # dedicated, backed-up plugin data volume.
               CLIPROXY_QUOTA_LEDGER_PATH: /CLIProxyAPI/plugin-data/managed-key-quota-ledger.json


### PR DESCRIPTION
Enables the dedicated owner-binding endpoint with a distinct SOPS-managed credential. The credential is separate from usage, reveal, and management secrets and is mirrored only to Employee Hub.\n\nValidation: kustomize build, SOPS encryption status, git diff check.