### PR TITLE
fix(cliproxy): expose Employee Hub owner-binding route

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -277,6 +277,9 @@ spec:
               - path: /internal/employee-hub/v1/api-key/reveal
                 pathType: Exact
                 service: *appService
+              - path: /internal/employee-hub/v1/api-key/owner-binding
+                pathType: Exact
+                service: *appService
           - host: &apiHost "cliproxyapi.davidhome.ro"
             paths: *openApiPaths
         tls:


### PR DESCRIPTION
Adds the exact owner-binding path to the public CLIProxy ingress. The endpoint itself remains bearer-protected and rejects trailing paths.\n\nProduction diagnosis: the new route returned 401 through an in-cluster port-forward but 404 at ingress, proving the application was healthy and only the exact path allowlist was missing.\n\nValidation: kustomize build and git diff check.