### PR TITLE
feat(cliproxy): expose authenticated usage routes

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -269,6 +269,12 @@ spec:
                 service: *appService
               - path: /backend-api/codex
                 service: *appService
+              - path: /backend-api/wham/usage
+                pathType: Exact
+                service: *appService
+              - path: /api/oauth/usage
+                pathType: Exact
+                service: *appService
               - path: /healthz
                 service: *appService
               - path: /internal/employee-hub/v1/usage


### PR DESCRIPTION
Expose the API-key-authenticated native Claude and Codex usage endpoints added by CLIProxyAPI PR #4. These paths stay outside DavidApps Gate so Tokmon can call them with a scoped CLIProxy API key; management remains Gate-protected and /metrics remains internal.