### PR TITLE
feat(plausible): roll out enterprise image

### DIFF
--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -64,8 +64,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/plausible/community-edition
-              tag: v3.2.1@sha256:33e60bfb40f2df5da00f8753b76fad04f67dba3abe6d73eb516e440e3fb62985
+              repository: ghcr.io/davidilie/plausible-enterprise
+              tag: v3.2.1@sha256:d38102aff07b6f80a68bd568f7d3103f321ccb30a414efbaf0902bbc395984d2
               pullPolicy: IfNotPresent
             command:
               - sh
@@ -99,6 +99,8 @@ spec:
                 cpu: 50m
                 memory: 768Mi
         pod:
+          imagePullSecrets:
+            - name: docker-regcred
           terminationGracePeriodSeconds: 1
           securityContext:
             runAsNonRoot: true

--- a/kubernetes/apps/observability/plausible/app/secret.sops.yaml
+++ b/kubernetes/apps/observability/plausible/app/secret.sops.yaml
@@ -19,6 +19,7 @@ stringData:
   SMTP_USER_NAME: ENC[AES256_GCM,data:/v6aoj9u8mZGX0cZiISfHSgsiQ==,iv:kYTPWZoTTpNTIRq4z9fRWNeuQKSvFP+QdPZIbGE0ISY=,tag:Z7LEGcr2BZVoNoLSYcclBg==,type:str]
   SMTP_USER_PWD: ENC[AES256_GCM,data:qmhBd2FUTw5XIYMair3e89bW/A==,iv:fWpR7NnPAeezTkenGIY/BXYqEyA1bnCX8J+ZKYb9f9k=,tag:y0LlBecW/MdXaMC/FnrKzQ==,type:str]
   CLICKHOUSE_DATABASE_URL: ENC[AES256_GCM,data:rFJMZ6WXkqCYq6RmxdL2SS7qxf9UdgceBQc2q37H4gBkq2L7f1FibnRl3Kt+YY19eajpzNAgqq0Nu0/uzxECXGaUMyU+StB4y1CBzsE1Hrnxyt7OvgRbFWmYnfvCKj8=,iv:rMLLad10DQiqk0jURd/ThcfgUpdZUCZBzSpdo9IxQg8=,tag:sDe0UtimCtyxYjyGtrpYJQ==,type:str]
+  LICENSE_KEY: ENC[AES256_GCM,data:gXTuaduTILYWqiogqJDs+LSYWGCRgQwayp+mxoXJWT6hUqZOVz9bRKjWyqMf4YOFtJmqDbaVhMu4oQb8z2UU+Q==,iv:bvGVprWSGBKiFRoX8l4K6AQ6Z7t16/cNajj3vVbVMRw=,tag:xw0ZwPh0Dgx3mlH/anUcgA==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -30,7 +31,7 @@ sops:
         ZjRmNHBIWUZWNUJiYVRneDdIZFJVaWMKe96/DUjIHImoaKXiXuh9WrZiVu8r8jdj
         ZWJZ+IV6jF7yXq3kNFN1yR9FwbQPuYdSw6UPMduTOcANIr9b7fOlZg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-01-22T11:06:35Z"
-  mac: ENC[AES256_GCM,data:Vbk6QHvkis9SpyuoyxbGpgYGJYcSZUcHSj2lwDT2c0vmWdETkZXpCN3nHK2H6NmiPS+KELlQkFvKZJQyWmtwL8VF3TAu4KyKU4P1LHMb2283h3Gta9nmT01PUiMSdGfKZW19OUhwPVdT3cXDevd0BTnhMzlYG0BkVuxUbQdywes=,iv:YFsdkw8cPhDMinaQ0I8g3JOLtQ6pth7bCl82u/pLFCE=,tag:IcAFK1FRk+94KBC8s52gnw==,type:str]
+  lastmodified: "2026-08-25T22:05:05Z"
+  mac: ENC[AES256_GCM,data:/GJ/jlv4GczIJtyLVuiri1f3nDXV+FK1U2NKLdm9r0V4ycqaUwmqaQQe+1QOKOmuh61zI6rcV7sw3IC/ulnnRR2MQOZOCd9//antLVp9LPOeH5Su3DTnjs4cUu99nLVBknbn878ll+tBi/farfkmQfuKsCSs8YpiZ7iS/ojmfqk=,iv:etEgwrRlBJAhdjNeC88Yz5pCLxemgmhTgk3bkHQN9BM=,tag:Qga34LIvcybumDhMYUuApw==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.11.0


### PR DESCRIPTION
## Summary
- replace Plausible CE v3.2.1 with the private Enterprise v3.2.1 image pinned by OCI digest
- use the existing GHCR pull secret
- provide the runtime license through the existing SOPS-encrypted Secret

## Safety
- dedicated PostgreSQL backup completed
- ClickHouse backup completed
- existing databases, service, ingress, and startup migration command remain unchanged
- SAML remains disabled during this rollout

## Validation
- `kubectl kustomize kubernetes/apps/observability/plausible/app`
- `git diff --check`