### PR TITLE
fix(cliproxy): configure managed key encryption

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/employee-hub-secret.sops.yaml
+++ b/kubernetes/apps/default/cliproxy/app/employee-hub-secret.sops.yaml
@@ -6,6 +6,7 @@ stringData:
   EMPLOYEE_HUB_SERVICE_TOKEN: ENC[AES256_GCM,data:7aj33k7DrIDxOlF052AirE4gKUVQLDX+4sBonwdmB8jMVgRfMB9XytLP393mcg67nko9yu4lAPTKe8cNMAsX7Q==,iv:6LRx5TWiXgOjowIB8WkmGqdxhPVWofBFIMhTmW/SWl4=,tag:VwyFXGcqq0NM7NToe6+g4w==,type:str]
   EMPLOYEE_HUB_REVEAL_TOKEN: ENC[AES256_GCM,data:uhsiGpciRG7n0sUbbNErjZB3Gf4R9eLKp16oNip6cwek+q7BZa+tTUw+lsULqnGAfolCMTS7TEb6vfeKvkXUNQ==,iv:1lwjR/Mn5knAwxIqJQ/43XEar+iSVFPLrYKac7Q+gm8=,tag:ZNqWG97lR+PpvfD5C9hSJg==,type:str]
   EMPLOYEE_HUB_BINDING_TOKEN: ENC[AES256_GCM,data:8kKZmWtLgCiu8nvg1UJE/RqUcuUGxDczkAoyaeefR8MvUABw8XUVc5dv7SGy4IOIcI+cRl1TQ2KbKZWmbnMESkkHgHKsX7LDVU9z03rPivP3hl6e4u5+0bhrzdVhEyme,iv:z1n9LAD4H9G2bA121TT9VA37BAXMLMz7LP1InR86hZ0=,tag:17Nl2ZLK2E1diSN5K6hWvg==,type:str]
+  CLIPROXY_API_KEY_ENCRYPTION_KEY: ENC[AES256_GCM,data:Z60mDLh7Y5jLZmLacLyVDruMKHyn6rZwhUJKNpvt8EG/5ittKMIcHFg/m/0=,iv:lyOWpMWUsvQ6LwDj3Bas8KC/3XXotUojSeDw7T22KV8=,tag:b6fqGFdha3brVUvw3PzGRw==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -17,8 +18,8 @@ sops:
         OXJmeGU0OEFLSVM0UEFtUzV5YU50L28K0Kfyk11vf0LMjngFpqfR7ZDQO1A9RMVN
         A/NmVaMufTyXuUksE2FSSP2+ztN3iGLpPBM4VPtCz3r6y9BWQuHC3g==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-25T17:39:33Z"
-  mac: ENC[AES256_GCM,data:3ebJBLfVarunUmVqyIO44OHc2ERfCUU12OGm68Y54D7LKEDBZlC7IX5mFDEjR6jjG4HaK8GshXZg0O7wgAk5qu6Gz1h1QyQrq9LLOgBb0/kWXR+oYMxFBuctRGUFs4DATNhFiE2Z9YKufymuBFb/GCto8eQI7gAlntgoerPlVSs=,iv:pn/NBQJZIMYu+s8WNoXNFbGPkwaXowq0pKiiRwYYngQ=,tag:zsbaS7Z2l8k/U+EP0n/KGw==,type:str]
+  lastmodified: "2026-08-25T22:32:48Z"
+  mac: ENC[AES256_GCM,data:BWKp0qZGM+y3s+RDiep23YbchHPiZGS0VsUPg1I1CLbwoHMQTa/K0KFDQDUCnREclCSWTPtnwFIw9gHRyPCl/iIS+gfn5Ep90n6sFlvl3jz9ccxfCOT9X4wDMfPj+E11k47LCZJf1+X5JDvhT946cd7Wn7K2f2ml2sV2jsMutl4=,iv:zoubcbnOwP2ZhDL4WUgnA4aE4spMD8OFh2v7seqrMn4=,tag:xGtfZTRp7hedB/qZEr8zYA==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
   version: 3.12.1

--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -193,6 +193,11 @@ spec:
                   secretKeyRef:
                     name: cliproxy-employee-hub
                     key: EMPLOYEE_HUB_BINDING_TOKEN
+              CLIPROXY_API_KEY_ENCRYPTION_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: cliproxy-employee-hub
+                    key: CLIPROXY_API_KEY_ENCRYPTION_KEY
               # Persist managed-key quota attribution across rollouts on the
               # dedicated, backed-up plugin data volume.
               CLIPROXY_QUOTA_LEDGER_PATH: /CLIProxyAPI/plugin-data/managed-key-quota-ledger.json


### PR DESCRIPTION
## Summary
- provision a random SOPS-encrypted 32-byte CLIProxy managed-key encryption key
- inject the key into the CLIProxy deployment
- unblock Employee Hub owner binding and verified API-key reveal

## Verification
- SOPS MAC and decryption verified locally
- encrypted value decodes to the required 32 bytes