### PR TITLE
fix(plausible): configure enterprise vault key

### DIFF
--- a/kubernetes/apps/observability/plausible/app/secret.sops.yaml
+++ b/kubernetes/apps/observability/plausible/app/secret.sops.yaml
@@ -20,6 +20,7 @@ stringData:
   SMTP_USER_PWD: ENC[AES256_GCM,data:qmhBd2FUTw5XIYMair3e89bW/A==,iv:fWpR7NnPAeezTkenGIY/BXYqEyA1bnCX8J+ZKYb9f9k=,tag:y0LlBecW/MdXaMC/FnrKzQ==,type:str]
   CLICKHOUSE_DATABASE_URL: ENC[AES256_GCM,data:rFJMZ6WXkqCYq6RmxdL2SS7qxf9UdgceBQc2q37H4gBkq2L7f1FibnRl3Kt+YY19eajpzNAgqq0Nu0/uzxECXGaUMyU+StB4y1CBzsE1Hrnxyt7OvgRbFWmYnfvCKj8=,iv:rMLLad10DQiqk0jURd/ThcfgUpdZUCZBzSpdo9IxQg8=,tag:sDe0UtimCtyxYjyGtrpYJQ==,type:str]
   LICENSE_KEY: ENC[AES256_GCM,data:gXTuaduTILYWqiogqJDs+LSYWGCRgQwayp+mxoXJWT6hUqZOVz9bRKjWyqMf4YOFtJmqDbaVhMu4oQb8z2UU+Q==,iv:bvGVprWSGBKiFRoX8l4K6AQ6Z7t16/cNajj3vVbVMRw=,tag:xw0ZwPh0Dgx3mlH/anUcgA==,type:str]
+  HELP_SCOUT_VAULT_KEY: ENC[AES256_GCM,data:N+v0u/ZDzJ6w5MCm8R9uOhxX/5qqLPSpWbZwaFzSmSQCcA6VEVLmt7NDEKY=,iv:a3rTFa2ZHazx2Y/Gjvxs4+C3OgcIhtP7RmBh8wtRNp8=,tag:oDMzeVYRSd5QQtgswVrsLw==,type:str]
 sops:
   age:
     - recipient: age1a62pe7lp5xdm2f5v8lhcdsvglht6hr7qvduc6ap2w79r8rqn09tq0fgjcn
@@ -31,7 +32,7 @@ sops:
         ZjRmNHBIWUZWNUJiYVRneDdIZFJVaWMKe96/DUjIHImoaKXiXuh9WrZiVu8r8jdj
         ZWJZ+IV6jF7yXq3kNFN1yR9FwbQPuYdSw6UPMduTOcANIr9b7fOlZg==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-08-25T22:05:05Z"
-  mac: ENC[AES256_GCM,data:/GJ/jlv4GczIJtyLVuiri1f3nDXV+FK1U2NKLdm9r0V4ycqaUwmqaQQe+1QOKOmuh61zI6rcV7sw3IC/ulnnRR2MQOZOCd9//antLVp9LPOeH5Su3DTnjs4cUu99nLVBknbn878ll+tBi/farfkmQfuKsCSs8YpiZ7iS/ojmfqk=,iv:etEgwrRlBJAhdjNeC88Yz5pCLxemgmhTgk3bkHQN9BM=,tag:Qga34LIvcybumDhMYUuApw==,type:str]
+  lastmodified: "2026-08-25T22:34:22Z"
+  mac: ENC[AES256_GCM,data:Jh88znSb3LELO8J/bYuvT+msc4MUA59PPt89QTjNl9GZKZTfoNOvWuKhq5th0ouNqbaXzl3oC+oMFKgVJ9em4AyUzb1qlRQuCWwjPdfsTJcFbS4J1kbLgBNKBjfhWfqcsPk+PPXDfl5jlj4HDRxmu1cscHbPVZiuY7spkeUC7Sk=,iv:oqO6elRdFBQBFIvOt5N/GXvR4DvVv6o8IJdTq9FXfrM=,tag:fHMQ2dSzamg6Ux1DYcl/5Q==,type:str]
   encrypted_regex: ^(data|stringData)$
   version: 3.11.0


### PR DESCRIPTION
## Summary
- add the Enterprise-only `HELP_SCOUT_VAULT_KEY` to the existing SOPS-encrypted Plausible Secret
- use a randomly generated Base64-encoded 32-byte key

## Context
The Enterprise v3.2.1 application starts its Help Scout vault unconditionally and exits when this value is absent. The previous CE pod remains healthy during the rolling update.

## Validation
- decrypted value decodes to exactly 32 bytes
- `git diff --check`