### PR TITLE
fix(cliproxy): mount config directory writable

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -147,6 +147,7 @@ spec:
             image:
               repository: ghcr.io/davidilie/cliproxyapi # {"$imagepolicy": "flux-system:cliproxy:name"}
               tag: main-d866fe9c-1787697512 # {"$imagepolicy": "flux-system:cliproxy:tag"}
+            args: ["-config", "/config-data/config.yaml"]
             env:
               TZ: Europe/Bucharest
               DAVIDAPPS_ASSERTION_ISSUER:
@@ -354,8 +355,7 @@ spec:
             config-bootstrap:
               - path: /data
             app:
-              - path: /CLIProxyAPI/config.yaml
-                subPath: config.yaml
+              - path: /config-data
       auths:
         existingClaim: cliproxy
         globalMounts:


### PR DESCRIPTION
## Summary
- mount the CLIProxy config PVC as a writable directory
- point CLIProxy at the persisted config through `-config`
- allow atomic owner-binding and credential-rotation saves without hiding the application binary

## Production evidence
- the config file itself was writable
- its `/CLIProxyAPI` parent directory was not writable
- owner binding therefore returned `500 binding_unavailable` during atomic save