### PR TITLE
fix(cliproxy): preserve container executable

### DIFF
--- a/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cliproxy/app/helmrelease.yaml
@@ -147,6 +147,7 @@ spec:
             image:
               repository: ghcr.io/davidilie/cliproxyapi # {"$imagepolicy": "flux-system:cliproxy:name"}
               tag: main-d866fe9c-1787697512 # {"$imagepolicy": "flux-system:cliproxy:tag"}
+            command: ["/CLIProxyAPI/CLIProxyAPI"]
             args: ["-config", "/config-data/config.yaml"]
             env:
               TZ: Europe/Bucharest


### PR DESCRIPTION
CLIProxy uses Docker `CMD` without an entrypoint, so Kubernetes args alone replaced the executable. Set the binary explicitly while retaining the writable config path.

Verified against the live deployment: rollout restored and the container is healthy.