### PR TITLE
fix(plausible): enable real SAML adapter

### DIFF
--- a/kubernetes/apps/observability/plausible/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plausible/app/helmrelease.yaml
@@ -79,6 +79,7 @@ spec:
               BASE_URL: https://plausible.davidapps.dev
               DISABLE_REGISTRATION: invite_only
               IP_GEOLOCATION_DB: /usr/share/GeoIP/GeoLite2-City.mmdb
+              SSO_SAML_ADAPTER: real
             envFrom:
               - secretRef:
                   name: plausible-secret


### PR DESCRIPTION
Configure the Enterprise runtime to use the real SAML adapter instead of Plausible’s default fake development adapter.